### PR TITLE
Added empty list as default value for train-exc input parameter

### DIFF
--- a/anomaly-shift/metadata.json
+++ b/anomaly-shift/metadata.json
@@ -12,7 +12,8 @@
     {
       "name": "train-exc",
       "type": "list",
-      "description": "Training dataset field exclusion list"
+      "description": "Training dataset field exclusion list",
+      "default":[]
     },
     {
       "name": "prod-dst",


### PR DESCRIPTION
Added an empty list value as the default value for the train-exc parameter as required with scripts in the BigML Dashboard.
