### PR TITLE
Adds script for global field importance for clusters

### DIFF
--- a/cluster-classification/metadata.json
+++ b/cluster-classification/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Cluster Classification",
+  "description": "Find the global field importance across a cluster",
+  "kind": "script",
+  "source_code": "script.whizzml",
+  "inputs": [
+      {
+          "name": "cluster-id",
+          "type": "cluster-id",
+          "description": "Cluster to be analyzed"
+      }
+  ],
+  "outputs": [
+      {
+          "name": "importance-list",
+          "type": "list",
+          "description": "Field importance results"
+      }
+  ]
+}

--- a/cluster-classification/readme.md
+++ b/cluster-classification/readme.md
@@ -1,0 +1,11 @@
+# Global Field Importance for Clusters
+
+This script determines which input fields are most important for
+differentiating between clusters. Given a cluster id, it:
+
+- Using batchcentroid, extends the dataset the cluster was
+  built on with the centroid id each instance is a member of.
+- Builds an ensemble (random forest) on that centroid id field.
+- Averages the importance of each input field across all models
+  in the ensemble.
+- Returns a sorted list of input fields by importance.

--- a/cluster-classification/script.whizzml
+++ b/cluster-classification/script.whizzml
@@ -9,8 +9,8 @@
 
 (define (label-by-cluster cl-id) 
   (let (cl (fetch cl-id)
-        cl-ds (get cl "dataset")
-        cl-fields (get cl "input_fields"))
+        cl-ds (cl "dataset")
+        cl-fields (cl "input_fields"))
     (create-and-wait-batchcentroid
      {"cluster" cl-id 
       "dataset" cl-ds 
@@ -40,10 +40,10 @@
 ;; field ids and average importances
 
 (define (make-importance-map en-id ids)
-  (let (models (get-in (fetch en-id) ["models"])
+  (let (models ((fetch en-id) ["models"])
         len-models (count models)
         imp-lst (map (lambda (md-id) 
-                       (get-in (fetch md-id) ["model" "importance"])) 
+                       ((fetch md-id) ["model" "importance"])) 
                      models)
         imp-map (map list-to-map imp-lst)
         imp-sum (reduce (lambda (x y) (merge-with + x y)) {} imp-map))
@@ -63,11 +63,11 @@
         labeled (bc "output_dataset_resource")
         new-ids (butlast ((fetch labeled) "input_fields"))
         cl-en (create-and-wait-ensemble labeled {"randomize" true})
-        ds-fields (get (fetch labeled) "fields")
+        ds-fields ((fetch labeled) "fields")
         imp-map (make-importance-map cl-en new-ids)
         name-map (make-map new-ids 
                            (map (lambda (x) 
-                                  (get-in ds-fields [x "name"])) 
+                                  (ds-fields [x "name"])) 
                                 new-ids))
         id-map (make-map new-ids old-ids)       
         total-map (map (lambda (x) 

--- a/cluster-classification/script.whizzml
+++ b/cluster-classification/script.whizzml
@@ -1,0 +1,84 @@
+;; Given a cluster, creates a batch centroid and uses the output
+;; dataset where each instance is labeled by centroid to create an
+;; ensemble (random forest), and returns the importance of each field
+;; averaged over the ensemble.
+
+;; Given a cluster, returns a batchcentroid id created from that
+;; cluster whose output dataset is the original cluster dataset
+;; appended with the centroids the instances are part of.
+
+(define (label-by-cluster cl-id) 
+  (let (cl (fetch cl-id)
+        cl-ds (get cl "dataset")
+        cl-fields (get cl "input_fields"))
+    (create-and-wait-batchcentroid
+     {"cluster" cl-id 
+      "dataset" cl-ds 
+      "output_dataset" true
+      "output_fields" cl-fields})))
+
+;; Given a list of pairs, creates the equivalent map
+
+(define (list-to-map nested-list)
+  (let (key-list (map head nested-list)
+        value-list (map (lambda (x) (last x)) nested-list))
+    (make-map key-list value-list)))
+
+;; Given a function of two values and two maps, returns a new map
+;; where if a key appears in only one of the original maps its value
+;; is unchanged, but if it appears in both its value is the function
+;; of the two original values.  
+
+(define (merge-with fn map1 map2) 
+  (let (subset-keys (filter (lambda (x) (contains? map1 x)) (keys map2))
+        subset-values (map (lambda (x) 
+                             (fn (get map1 x) (get map2 x))) subset-keys) 
+        subset (make-map subset-keys subset-values)) 
+    (merge map1 (merge map2 subset))))
+
+;; Given a ensemble id and a list of field ids, returns a map of those
+;; field ids and average importances
+
+(define (make-importance-map en-id ids)
+  (let (models (get-in (fetch en-id) ["models"])
+        len-models (count models)
+        imp-lst (map (lambda (md-id) 
+                       (get-in (fetch md-id) ["model" "importance"])) 
+                     models)
+        imp-map (map list-to-map imp-lst)
+        imp-sum (reduce (lambda (x y) (merge-with + x y)) {} imp-map))
+    (make-map ids (map (lambda (x) 
+                         (if (contains? imp-sum x) 
+                           (/ (get imp-sum x) len-models) 0)) 
+                       ids))))
+
+;; Given a cluster-id, builds a random forest on centroid membership,
+;; and returns a paired list of field importance averaged across all
+;; models in the forest
+
+(define (cluster-classification cl-id)
+  (let (bc-id (label-by-cluster cl-id)
+        bc (fetch bc-id)
+        old-ids (bc "output_fields")
+        labeled (bc "output_dataset_resource")
+        new-ids (butlast ((fetch labeled) "input_fields"))
+        cl-en (create-and-wait-ensemble labeled {"randomize" true})
+        ds-fields (get (fetch labeled) "fields")
+        imp-map (make-importance-map cl-en new-ids)
+        name-map (make-map new-ids 
+                           (map (lambda (x) 
+                                  (get-in ds-fields [x "name"])) 
+                                new-ids))
+        id-map (make-map new-ids old-ids)       
+        total-map (map (lambda (x) 
+                         (make-map ["field id", "name", "importance"] 
+                                   [(get id-map x), 
+                                    (get name-map x), 
+                                    (get imp-map x)])) 
+                       (keys imp-map)))
+  (delete* [labeled bc-id cl-en])
+  (reverse (sort-by-key "importance" total-map))))
+
+;; Putting it all together...
+(define importance-list 
+  (cluster-classification cluster-id))

--- a/metadata.json
+++ b/metadata.json
@@ -17,6 +17,7 @@
     "seeded-best-k",
     "anomaly-shift",
     "cross-validation",
-    "boruta"
+    "boruta",
+    "cluster-classification"
   ]
 }

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,8 @@ By convention, when the artifact is a library, the files are called
 - `cross-validation` Scripts for performing k-fold crossvalidation.
 - `clean-dataset` Scripts and library for cleaning up a dataset.
 - `boruta` Script for feature selection using the Boruta algorithm.
+- `cluster-classification` Script that determines which input fields
+  are most important for differentiating between clusters
 
 
 ## Compiling packages and running tests


### PR DESCRIPTION
A script to determine which input fields are globally most important when differentiating between clusters. 

@jaor, would it be appropriate to put in a PR to add `merge-with` to the WhizzML standard library?
