### PR TITLE
Replace 'resource' tag in a few scripts' metadata.json with 'kind'

### DIFF
--- a/model-per-cluster/batch-prediction/metadata.json
+++ b/model-per-cluster/batch-prediction/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "Batch predictions with cluster models",
   "description": "Perform a batch prediction using cluster models",
-  "resource": "script",
+  "kind": "script",
   "source_code": "script.whizzml",
   "inputs": [
     {

--- a/model-per-cluster/single-prediction/metadata.json
+++ b/model-per-cluster/single-prediction/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "Single predictions with cluster models",
   "description": "Perform a single prediction using cluster models",
-  "resource": "script",
+  "kind": "script",
   "source_code": "script.whizzml",
   "inputs": [
     {

--- a/remove-anomalies/metadata.json
+++ b/remove-anomalies/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "Remove Anomalies",
   "description": "Remove the top n anomalies from a dataset",
-  "resource": "script",
+  "kind": "script",
   "source_code": "script.whizzml",
   "inputs": [
     {


### PR DESCRIPTION
The following scripts/libraries:

model-per-cluster/batch-prediction
model-per-cluster/single-prediction
remove-anomalies

were using

`'resource' : 'xxxx'`

instead of the correct (I think)

`'kind' : 'xxxx'`.
