### PR TITLE
Auto-complete Dataset

### DIFF
--- a/repair-missing/metadata.json
+++ b/repair-missing/metadata.json
@@ -1,25 +1,37 @@
 {
   "name": "Auto-complete Missing Fields",
-  "description": "Use dataset information to fill in missing values for numeric or categorical fields which have at least one value missing.  For numeric fields, we learn a random forest to predict a probable field value given the information that is present.  For categorical fields we add an explict 'missing' category to the field.  In both cases, we also add a binary column indicating whether the value was missing in the original dataset or not.",
+  "description": "This script fills in missing values for all columns in a given dataset.  For numeric and categorical fields, this script uses the input fields of the dataset to learn models that predict the missing values.  For text and items fields, missing values are replaced by the empty string.  We also add a binary column indicating whether the value was missing in the original dataset or not.  Non-preferred fields are removed.  See the readme for more information.",
   "kind": "script",
   "source_code": "script.whizzml",
   "inputs": [
       {
           "name": "dataset-id",
           "type": "dataset-id",
-          "description": "Dataset to be completed"
+          "description": "Dataset to be Completed"
       },
       {
-          "name": "objective-field-id",
+          "name": "objective-field",
           "type": "string",
-          "description": "Objective field of the input dataset, or null to choose the default objective"
+          "default": "",
+          "description": "Objective field of the input dataset, or the empty string to choose the default objective.  If use-objective is true, this field is excluded from the missing field models and placed at the end of the output dataset."
+      }
+      {
+          "name": "use-objective",
+          "type": "boolean",
+          "default": true,
+          "description": "Whether or not to use an objective field"
       }
   ],
   "outputs": [
       {
-          "name": "completed-dataset",
+          "name": "repaired-dataset",
           "type": "dataset-id",
           "description": "Dataset with completed columns added"
+      }
+      {
+          "name": "processor",
+          "type": "map",
+          "description": "A collection of information about the repair process, including the models learned to replace missing data.  Can be to complete future datasets of the same format."
       }
   ]
 }

--- a/repair-missing/metadata.json
+++ b/repair-missing/metadata.json
@@ -31,7 +31,7 @@
       {
           "name": "processor",
           "type": "map",
-          "description": "A collection of information about the repair process, including the models learned to replace missing data.  Can be to complete future datasets of the same format."
+          "description": "A collection of information about the repair process, including the models learned to replace missing data.  Can be used to complete future datasets of the same format."
       }
   ]
 }

--- a/repair-missing/metadata.json
+++ b/repair-missing/metadata.json
@@ -1,0 +1,25 @@
+{
+  "name": "Auto-complete Missing Fields",
+  "description": "Use dataset information to fill in missing values for numeric or categorical fields which have at least one value missing.  For numeric fields, we learn a random forest to predict a probable field value given the information that is present.  For categorical fields we add an explict 'missing' category to the field.  In both cases, we also add a binary column indicating whether the value was missing in the original dataset or not.",
+  "kind": "script",
+  "source_code": "script.whizzml",
+  "inputs": [
+      {
+          "name": "dataset-id",
+          "type": "dataset-id",
+          "description": "Dataset to be completed"
+      },
+      {
+          "name": "objective-field-id",
+          "type": "string",
+          "description": "Objective field of the input dataset, or null to choose the default objective"
+      }
+  ],
+  "outputs": [
+      {
+          "name": "completed-dataset",
+          "type": "dataset-id",
+          "description": "Dataset with completed columns added"
+      }
+  ]
+}

--- a/repair-missing/metadata.json
+++ b/repair-missing/metadata.json
@@ -14,7 +14,7 @@
           "type": "string",
           "default": "",
           "description": "Objective field of the input dataset, or the empty string to choose the default objective.  If use-objective is true, this field is excluded from the missing field models and placed at the end of the output dataset."
-      }
+      },
       {
           "name": "use-objective",
           "type": "boolean",
@@ -27,7 +27,7 @@
           "name": "repaired-dataset",
           "type": "dataset-id",
           "description": "Dataset with completed columns added"
-      }
+      },
       {
           "name": "processor",
           "type": "map",

--- a/repair-missing/readme.md
+++ b/repair-missing/readme.md
@@ -1,0 +1,21 @@
+# Missing Field Completion
+
+## Tests
+
+The `test` directory contains a shell script named `test.sh`
+which uses `BigMLer` to perform a basic test of the WhizzML code. To run the
+test:
+
+- BigMLer must be installed. For instructions to install BigMLer please refer
+to the [BigMLer documentation](http://bigmler.readthedocs.io/en/latest/#bigmler-installation).
+- Your credentials must be set as environment variables. Please refer to
+the [BigML Authentication](http://bigmler.readthedocs.io/en/latest/#bigml-authentication)
+section of docs for details.
+
+Once the setup is complete, go to the test directory and run the shell script
+
+```
+bash
+cd test
+./test.sh
+```

--- a/repair-missing/readme.md
+++ b/repair-missing/readme.md
@@ -1,18 +1,59 @@
-# Missing Field Completion
+# Dataset Repair
+
+The idea behind this script is to take a dataset as input and return a
+"clean" dataset with no missing value (except possibly in the
+objective) and no non-preferred fields.
+
+The script "completes" missing fields by using predictive models to
+impute value where they are missing.  The result is a dataset with the
+columns containing missing values replaced by columns with the missing
+values imputed.  In addition, for each completed column, we add a
+binary column indicating whether or not the value was missing in the
+original dataset.  We also remove non-preferred columns.
+
+## Some Details
+
+The script learns a random forest for each numeric or categorical
+field that has missing data.  The random forest is trained with the
+BigML defaults and uses all fields as input (except the objective
+field if specified).  The training data for each field is composed of
+all rows except those missing the target field value.
+
+After training, we make predictions for all rows using the learned
+model.  A flatline expression is then used to select between the
+original field value (if present) or the prediction (if the original
+is missing).
+
+An additional binary column is generated for each field that required
+completing, describing whether or not the field was missing in the
+original column.  This is useful in the case where data is missing for
+a reaason that may have relevant semantics (such as a doctor deciding not to
+administer a specific medical test).
+
+For "text" or "items" fields, we replace missing values with the empty
+string.  As text and items fields essentially comprise a set of binary
+features, the empty string gives a sensible replacement for those
+features.  We also generate the "was missing" column in this case.
+
+Datetime fields are not imputed directly, but their constituient
+fields are.
 
 ## Tests
 
-The `test` directory contains a shell script named `test.sh`
-which uses `BigMLer` to perform a basic test of the WhizzML code. To run the
+The `test` directory contains a shell script named `test.sh` which
+uses `BigMLer` to perform a basic test of the WhizzML code. To run the
 test:
 
-- BigMLer must be installed. For instructions to install BigMLer please refer
-to the [BigMLer documentation](http://bigmler.readthedocs.io/en/latest/#bigmler-installation).
-- Your credentials must be set as environment variables. Please refer to
-the [BigML Authentication](http://bigmler.readthedocs.io/en/latest/#bigml-authentication)
+- BigMLer must be installed. For instructions to install BigMLer
+please refer to the [BigMLer
+documentation](http://bigmler.readthedocs.io/en/latest/#bigmler-installation).
+- Your credentials must be set as environment variables. Please refer
+to the [BigML
+Authentication](http://bigmler.readthedocs.io/en/latest/#bigml-authentication)
 section of docs for details.
 
-Once the setup is complete, go to the test directory and run the shell script
+Once the setup is complete, go to the test directory and run the shell
+script
 
 ```
 bash

--- a/repair-missing/readme.md
+++ b/repair-missing/readme.md
@@ -27,7 +27,7 @@ is missing).
 An additional binary column is generated for each field that required
 completing, describing whether or not the field was missing in the
 original column.  This is useful in the case where data is missing for
-a reaason that may have relevant semantics (such as a doctor deciding not to
+a reason that may have relevant semantics (such as a doctor deciding not to
 administer a specific medical test).
 
 For "text" or "items" fields, we replace missing values with the empty
@@ -35,7 +35,7 @@ string.  As text and items fields essentially comprise a set of binary
 features, the empty string gives a sensible replacement for those
 features.  We also generate the "was missing" column in this case.
 
-Datetime fields are not imputed directly, but their constituient
+Datetime fields are not imputed directly, but their constituent
 fields are.
 
 ## Tests

--- a/repair-missing/readme.md
+++ b/repair-missing/readme.md
@@ -58,5 +58,8 @@ script
 ```
 bash
 cd test
-./test.sh
+VERBOSITY=0 ./test.sh
 ```
+
+Note that changing the value of `VERBOSITY` to either 1 or 2 will give
+you increasing levels of output as the tests are running.

--- a/repair-missing/readme.md
+++ b/repair-missing/readme.md
@@ -1,15 +1,15 @@
 # Dataset Repair
 
 The idea behind this script is to take a dataset as input and return a
-"clean" dataset with no missing value (except possibly in the
-objective) and no non-preferred fields.
+"clean" dataset with no missing values (except possibly in the
+objective) and only "preferred" fields.
 
 The script "completes" missing fields by using predictive models to
 impute value where they are missing.  The result is a dataset with the
 columns containing missing values replaced by columns with the missing
 values imputed.  In addition, for each completed column, we add a
 binary column indicating whether or not the value was missing in the
-original dataset.  We also remove non-preferred columns.
+original dataset.  Finally, we also remove non-preferred columns.
 
 ## Some Details
 
@@ -21,8 +21,8 @@ all rows except those missing the target field value.
 
 After training, we make predictions for all rows using the learned
 model.  A flatline expression is then used to select between the
-original field value (if present) or the prediction (if the original
-is missing).
+original field value (if present) or the prediction (if the value in
+the original field is missing).
 
 An additional binary column is generated for each field that required
 completing, describing whether or not the field was missing in the

--- a/repair-missing/script.whizzml
+++ b/repair-missing/script.whizzml
@@ -1,0 +1,192 @@
+;; This is a hack:  Field IDs are not conserved at batch prediction time, so
+;; we need to make sure that all of the fields have assigned IDs exactly as
+;; batch prediction will assign them (which essentially amounts to putting
+;; generated fields at the end).  To do this, we make a dummy model, do a dummy
+;; batch prediction, then remove the dummy column.
+(define (flatten-dataset dataset-id)
+  (let (fds ((fetch dataset-id) "fields"))
+    (if (some (lambda (fid) (= ((fds fid) "optype") "datetime")) (keys fds))
+      (let (_ (log-info "Generated fields detected.  Flattening dataset...")
+            mod-id (create-model dataset-id)
+            bp (create-batchprediction {"dataset" dataset-id
+                                        "all_fields" true
+                                        "output_dataset" true
+                                        "model" (wait mod-id)
+                                        "prediction_name" "__bmldummy"})
+            pred-ds ((fetch (wait bp)) "output_dataset_resource")
+            new_fields ((fetch (wait pred-ds)) "fields")
+            pred_fid (id-from-fields new_fields "__bmldummy")
+            final-ds (wait (create-dataset {"origin_dataset" pred-ds
+                                            "excluded_fields" [pred_fid]})))
+        (delete* [mod-id pred-ds bp])
+        final-ds)
+      dataset-id)))
+
+;; Helper function to get the ID of a field given its name
+(define (id-from-fields fields name)
+  (loop (ids (keys fields) vs (values fields))
+    (cond (empty? ids) false
+          (= name ((head vs) "name" false)) (head ids)
+          (recur (tail ids) (tail vs)))))
+
+;; Resolve the objective field ID given the input.  Choose the default
+;; if it's empty but we still want to use an objective.
+(define (get-objective use-objective dataset-id input)
+  (let (fds ((fetch dataset-id) "fields"))
+    (cond (not use-objective) false
+          (empty? input) (dataset-get-objective-id dataset-id)
+          (contains? fds input) input
+          (let (oid (id-from-fields fds input))
+            (if oid
+              oid
+              (raise (str "Objective field '" input "' not found!")))))))
+
+;; Find fields that are missing data.  As a bonus, we'll find
+;; non-preferred fields and exclude them later.
+(define (get-bad-fields fds objective-field)
+  (let (exclude? (lambda (fid) (not (or ((fds fid) "preferred")
+                                        (= fid objective-field))))
+        to-exclude (sort (filter exclude? (keys fds)))
+        repair? (lambda (fid) (and (> (((fds fid) "summary") "missing_count") 0)
+                                   (not (member? fid to-exclude))))
+        to-repair (sort (filter repair? (keys fds))))
+    [to-repair to-exclude]))
+
+;; Compose a dataset containing only rows for which the specified
+;; field ID isn't missing
+(define (filter-missing dataset-id field-id)
+  (let (fexpr (str "(not (missing \"" field-id "\"))"))
+    (create-dataset {"origin_dataset" dataset-id "lisp_filter" fexpr})))
+
+;; Create a model with the given dataset for the given field ID if it
+;; is a modelable type, else return the empty string as a dummy
+;; resource ID.
+(define (make-model ds-name train-ds fid fdesc obj-id)
+  (if (member? (fdesc "optype") ["numeric" "categorical"])
+    (create-ensemble {"dataset" train-ds
+                      "excluded_fields" (if obj-id [obj-id] [])
+                      "objective_field" fid
+                      "randomize" true
+                      "name" (str ds-name " - " fid)})
+    ""))
+
+;; Iterate through the map of models and make a prediction for each of
+;; the modeled fields, adding columns to the end of the dataset.
+;; Ignores keys mapped to the empty string, which denotes an
+;; unmodelable items or text field
+(define (dataset-with-predictions dataset-id model-map)
+  (log-info "Predicting output for " (count model-map) " fields...")
+  (loop (ds dataset-id fids (sort (keys model-map)))
+    (when (not (empty? fids))
+      (log-info "Making predictions for field " (head fids)))
+    (if (empty? fids)
+      ds
+      (if (empty? (model-map (head fids)))
+        (recur ds (tail fids))
+        (let (fname (str (head fids) "_pred")
+              bp (create-batchprediction {"dataset" ds
+                                          "all_fields" true
+                                          "output_dataset" true
+                                          "ensemble" (model-map (head fids))
+                                          "prediction_name" fname})
+              ods (wait ((fetch (wait bp)) "output_dataset_resource")))
+          (delete bp)
+          (when (not (= (head fids) (head (sort (keys model-map))))) (delete ds))
+          (recur ods (tail fids)))))))
+
+
+;; Compose Flatline expressions for choosing the value from a
+;; predicted field if the value in the original field is missing, or,
+;; in the case of text/items fields, replace with the empty string.
+(define (missing-exprs fid fdesc)
+  (let (pred (str fid "_pred")
+        expr (if (member? (fdesc "optype") ["numeric" "categorical"])
+               (flatline "(if (missing? {{fid}}) (f {{pred}}) (f {{fid}}))")
+               (flatline "(if (missing? {{fid}}) \"\" (f {{fid}}))")))
+     [expr (flatline "(if (missing? {{fid}}) true false)")]))
+
+;; Create names for the added fields, one each for the field with the
+;; missing values replaced by predictions, and the binary "was
+;; missing" column.
+(define (missing-names fdesc)
+  [(str (fdesc "name") " - Completed") (str (fdesc "name") " - Missing")])
+
+;; This function iterates through the fields with missing data, using
+;; flatline to choose the field value if there is one and the value
+;; predicted by the model if there isn't.  We also add a boolean
+;; column specifying which value was chosen.  It also moves the
+;; objective field to the end of the dataset if it exists (when making
+;; a batch prediction, for example, there might not be an objective
+;; field present).
+(define (choose-fields original-name dataset-id processor)
+  (log-info "Filling missing values with predictions in " dataset-id)
+  (let (fds ((fetch dataset-id) "fields")
+        oid (processor "objective_field")
+        oexpr (flatline "(f {{oid}})")
+        fids (sort (keys (processor "model_map")))
+        fdescs (map fds fids)
+        obj-present? (and oid (contains? fds oid))
+        ;; If the objective field is present, move it to the end
+        names (apply concat (map missing-names fdescs))
+        names (if obj-present? (append names ((fds oid) "name")) names)
+        exprs (apply concat (map missing-exprs fids fdescs))
+        exprs (if obj-present? (append exprs oexpr) exprs)
+        fs (map (lambda (n e) {"name" n "field" e}) names exprs)
+        temp-ids (lambda (fid) [fid (id-from-fields fds (str fid "_pred"))])
+        exids (concat (if obj-present? [oid] [])
+                      (processor "excluded_fields")
+                      (apply concat (map temp-ids fids)))
+        new-ds (create-dataset {"origin_dataset" dataset-id
+                                "name" (str original-name  " - Completed")
+                                "all_but" (filter identity exids)
+                                "new_fields" fs}))
+    (log-info "Creating completed fields...")
+    (wait new-ds)))
+
+;; Learn a structure that contains information for "repairing"
+;; datasets with missing values: For each column that is missing
+;; values, we create a model for that field, using all values to
+;; predict it except the objective.  The returned structure has the
+;; fields of the original dataset, the specified objective, a map from
+;; field ids to model ids contain the predictors learned, and a list
+;; of fields to be excluded (mostly non-preferred fields.  The
+;; structure can be passed to `repair-dataset` to fill in the missing
+;; values for another dataset.
+(define (learn-processor dataset-id objective-field use-objective)
+  (let (ofid (get-objective use-objective dataset-id objective-field)
+        dname ((fetch dataset-id) "name")
+        _  (log-info "Objective field is " ofid)
+        dsid (flatten-dataset dataset-id)
+        ods (fetch dsid)
+        fds (ods "fields")
+        [to-repair to-exclude] (get-bad-fields fds ofid)
+        fdescs (map fds to-repair)
+        _ (log-info "Fields to complete: " to-repair)
+        dss (map (lambda (fid) (filter-missing dsid fid)) to-repair)
+        make-mod (lambda (ds fid fdesc) (make-model dname ds fid fdesc ofid))
+        _ (log-info "Creating filtered datasets...")
+        models (map make-mod dss to-repair fdescs)
+        _ (wait* (filter (lambda (id) (not (empty? id))) models))
+        _ (log-info "Modeling missing values..."))
+    (delete* dss)
+    (when (not (= dsid dataset-id)) (delete dsid))
+    {"fields" fds
+     "objective_field" ofid
+     "model_map" (make-map to-repair models)
+     "excluded_fields" to-exclude}))
+
+;; Use the processor from `learn-processor` to "repair" a dataset:
+;; Make predictions for the columns that may have missing values, then
+;; use a flatline expression to fill in the missing values with
+;; predicitons.  Also eliminate non-preferred fields.
+(define (repair-dataset dataset-id processor)
+  (let (dsid (flatten-dataset dataset-id)
+        predset (dataset-with-predictions dsid (processor "model_map"))
+        outset (choose-fields ((fetch dsid) "name") predset processor))
+    (when (not (= dsid dataset-id)) (delete dsid))
+    (delete predset)
+    outset))
+
+;; (define processor (learn-processor dataset-id objective-field use-objective))
+
+;; (define repaired-dataset (repair-dataset dataset-id processor))

--- a/repair-missing/script.whizzml
+++ b/repair-missing/script.whizzml
@@ -187,6 +187,6 @@
     (delete predset)
     outset))
 
-;; (define processor (learn-processor dataset-id objective-field use-objective))
+(define processor (learn-processor dataset-id objective-field use-objective))
 
-;; (define repaired-dataset (repair-dataset dataset-id processor))
+(define repaired-dataset (repair-dataset dataset-id processor))

--- a/repair-missing/script.whizzml
+++ b/repair-missing/script.whizzml
@@ -170,8 +170,7 @@
         _ (log-info "Modeling missing values..."))
     (delete* dss)
     (when (not (= dsid dataset-id)) (delete dsid))
-    {"fields" fds
-     "objective_field" ofid
+    {"objective_field" ofid
      "model_map" (make-map to-repair models)
      "excluded_fields" to-exclude}))
 
@@ -182,7 +181,7 @@
 (define (repair-dataset dataset-id processor)
   (let (dsid (flatten-dataset dataset-id)
         predset (dataset-with-predictions dsid (processor "model_map"))
-        outset (choose-fields ((fetch dsid) "name") predset processor))
+        outset (choose-fields ((fetch dataset-id) "name") predset processor))
     (when (not (= dsid dataset-id)) (delete dsid))
     (delete predset)
     outset))

--- a/repair-missing/script.whizzml
+++ b/repair-missing/script.whizzml
@@ -24,10 +24,7 @@
 
 ;; Helper function to get the ID of a field given its name
 (define (id-from-fields fields name)
-  (loop (ids (keys fields) vs (values fields))
-    (cond (empty? ids) false
-          (= name ((head vs) "name" false)) (head ids)
-          (recur (tail ids) (tail vs)))))
+  (some (lambda (fid) (when (= ((fields fid) "name") name) fid)) (keys fields)))
 
 ;; Resolve the objective field ID given the input.  Choose the default
 ;; if it's empty but we still want to use an objective.

--- a/repair-missing/script.whizzml
+++ b/repair-missing/script.whizzml
@@ -1,27 +1,3 @@
-;; This is a hack:  Field IDs are not conserved at batch prediction time, so
-;; we need to make sure that all of the fields have assigned IDs exactly as
-;; batch prediction will assign them (which essentially amounts to putting
-;; generated fields at the end).  To do this, we make a dummy model, do a dummy
-;; batch prediction, then remove the dummy column.
-(define (flatten-dataset dataset-id)
-  (let (fds ((fetch dataset-id) "fields"))
-    (if (some (lambda (fid) (= ((fds fid) "optype") "datetime")) (keys fds))
-      (let (_ (log-info "Generated fields detected.  Flattening dataset...")
-            mod-id (create-model dataset-id)
-            bp (create-batchprediction {"dataset" dataset-id
-                                        "all_fields" true
-                                        "output_dataset" true
-                                        "model" (wait mod-id)
-                                        "prediction_name" "__bmldummy"})
-            pred-ds ((fetch (wait bp)) "output_dataset_resource")
-            new_fields ((fetch (wait pred-ds)) "fields")
-            pred_fid (id-from-fields new_fields "__bmldummy")
-            final-ds (wait (create-dataset {"origin_dataset" pred-ds
-                                            "excluded_fields" [pred_fid]})))
-        (delete* [mod-id pred-ds bp])
-        final-ds)
-      dataset-id)))
-
 ;; Helper function to get the ID of a field given its name
 (define (id-from-fields fields name)
   (some (lambda (fid) (when (= ((fields fid) "name") name) fid)) (keys fields)))
@@ -152,22 +128,20 @@
 ;; values for another dataset.
 (define (learn-processor dataset-id objective-field use-objective)
   (let (ofid (get-objective use-objective dataset-id objective-field)
-        dname ((fetch dataset-id) "name")
+        ods (fetch dataset-id)
+        dname (ods "name")
         _  (log-info "Objective field is " ofid)
-        dsid (flatten-dataset dataset-id)
-        ods (fetch dsid)
         fds (ods "fields")
         [to-repair to-exclude] (get-bad-fields fds ofid)
         fdescs (map fds to-repair)
         _ (log-info "Fields to complete: " to-repair)
-        dss (map (lambda (fid) (filter-missing dsid fid)) to-repair)
+        dss (map (lambda (fid) (filter-missing dataset-id fid)) to-repair)
         make-mod (lambda (ds fid fdesc) (make-model dname ds fid fdesc ofid))
         _ (log-info "Creating filtered datasets...")
         models (map make-mod dss to-repair fdescs)
         _ (wait* (filter (lambda (id) (not (empty? id))) models))
         _ (log-info "Modeling missing values..."))
     (delete* dss)
-    (when (not (= dsid dataset-id)) (delete dsid))
     {"objective_field" ofid
      "model_map" (make-map to-repair models)
      "excluded_fields" to-exclude}))
@@ -177,10 +151,8 @@
 ;; use a flatline expression to fill in the missing values with
 ;; predicitons.  Also eliminate non-preferred fields.
 (define (repair-dataset dataset-id processor)
-  (let (dsid (flatten-dataset dataset-id)
-        predset (dataset-with-predictions dsid (processor "model_map"))
+  (let (predset (dataset-with-predictions dataset-id (processor "model_map"))
         outset (choose-fields ((fetch dataset-id) "name") predset processor))
-    (when (not (= dsid dataset-id)) (delete dsid))
     (delete predset)
     outset))
 

--- a/repair-missing/script.whizzml
+++ b/repair-missing/script.whizzml
@@ -48,6 +48,7 @@
                                         (= fid objective-field))))
         to-exclude (sort (filter exclude? (keys fds)))
         repair? (lambda (fid) (and (> (((fds fid) "summary") "missing_count") 0)
+                                   (not (= fid objective-field))
                                    (not (member? fid to-exclude))))
         to-repair (sort (filter repair? (keys fds))))
     [to-repair to-exclude]))

--- a/repair-missing/test/check_output.py
+++ b/repair-missing/test/check_output.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import json
+import sys
+
+with open(sys.argv[1], "rb") as fin:
+    data = json.load(fin)
+
+if "outputs" not in data:
+    exit(1)
+
+output_map = {output[0]: output[1] for output in data['outputs']}
+
+if "repaired-dataset" not in output_map.keys():
+    exit(1)
+if "processor" not in output_map.keys():
+    exit(1)
+if "model_map" not in output_map['processor']:
+    exit(1)
+if not isinstance(output_map['processor']['model_map'], dict):
+    exit(1)
+if not isinstance(output_map['processor']['excluded_fields'], list):
+    exit(1)
+
+models = output_map['processor']['model_map']
+
+for field in models:
+    if models[field] != "" and not models[field].startswith("ensemble"):
+        exit(1)
+
+exit(0)

--- a/repair-missing/test/test.sh
+++ b/repair-missing/test/test.sh
@@ -7,34 +7,42 @@ rm -f -R cmd
 rm -f -R .build
 
 log "-------------------------------------------------------"
-log "Test for boruta script"
+log "Test for Auto-complete Dataset script"
 run_bigmler whizzml --package-dir ../ --output-dir ./.build
+
 # creating the resources needed to run the test
-run_bigmler --train s3://bigml-public/csv/iris.csv --no-model \
+run_bigmler --train s3://bigml-public/csv/kaggle_titanic_train.csv --no-model \
             --project "Whizzml examples tests" --output-dir cmd/pre_test
+
 # building the inputs for the test
 prefix='[["dataset-id", "'
 suffix='"]]'
-text=''
+
 cat cmd/pre_test/dataset | while read dataset
 do
 echo "$prefix$dataset$suffix" > "test_inputs.json"
 done
-log "Testing 1-click boruta script ----------------------------------"
+log "Testing Auto-complete Dataset script ----------------------------------"
+
 # running the execution with the given inputs
 run_bigmler execute --scripts .build/scripts --inputs test_inputs.json \
                     --output-dir cmd/results
 # check the outputs
 declare file="cmd/results/whizzml_results.json"
-declare regex="\"outputs\": \[\[\"feature-selected-dataset\", "
-declare file_content=$( cat "${file}" )
-if [[ " $file_content " =~ $regex ]]
+
+# use python script to check output
+./check_output.py $file
+
+# report results
+if [[ $? -eq 0 ]]
     then
-        log "boruta 1-click OK"
-    else
-        echo "boruta 1-click KO:\n $file_content"
-        exit 1
+        log "Auto-Complete Dataset OK"
+else
+    echo "Auto-Complete Dataset KO:"
+    cat "$file" | python -m json.tool
+    exit 1
 fi
+
 # remove the created resources
 run_bigmler delete --from-dir cmd --output-dir cmd_del
 run_bigmler delete --from-dir .build --output-dir cmd_del

--- a/repair-missing/test/test.sh
+++ b/repair-missing/test/test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+source ../../test-utils.sh
+
+rm -f -R cmd_del
+rm -f -R cmd
+rm -f -R .build
+
+log "-------------------------------------------------------"
+log "Test for boruta script"
+run_bigmler whizzml --package-dir ../ --output-dir ./.build
+# creating the resources needed to run the test
+run_bigmler --train s3://bigml-public/csv/iris.csv --no-model \
+            --project "Whizzml examples tests" --output-dir cmd/pre_test
+# building the inputs for the test
+prefix='[["dataset-id", "'
+suffix='"]]'
+text=''
+cat cmd/pre_test/dataset | while read dataset
+do
+echo "$prefix$dataset$suffix" > "test_inputs.json"
+done
+log "Testing 1-click boruta script ----------------------------------"
+# running the execution with the given inputs
+run_bigmler execute --scripts .build/scripts --inputs test_inputs.json \
+                    --output-dir cmd/results
+# check the outputs
+declare file="cmd/results/whizzml_results.json"
+declare regex="\"outputs\": \[\[\"feature-selected-dataset\", "
+declare file_content=$( cat "${file}" )
+if [[ " $file_content " =~ $regex ]]
+    then
+        log "boruta 1-click OK"
+    else
+        echo "boruta 1-click KO:\n $file_content"
+        exit 1
+fi
+# remove the created resources
+run_bigmler delete --from-dir cmd --output-dir cmd_del
+run_bigmler delete --from-dir .build --output-dir cmd_del
+rm -f -R test_inputs.json cmd cmd_del
+rm -f -R .build .bigmler*


### PR DESCRIPTION
This is a little script that takes a dataset that may have missing data, trains a model for each missing field, and uses the model to fill in the missing data.  It also inserts empty strings for missing text/items fields and removes non-preferred fields in the bargain.  Finally, for each missing field that it had to "complete", it adds a column indicating whether or not the field was missing in the original dataset.

This may be useful for the upcoming Laminar, as DBNs don't deal with missing data in a natural way.  Also for logistic regression where we don't feel like our built-in options for imputation are enough (/cc @cheesinglee).

This was inspired by the talks that Poul and I gave in Valencia, as well as a conversation I had afterwards with someone who asked for it specifically.

@jaor - Is there a reason that Poul and FM aren't in this group?  I'd like to cc them but I guess I can't unless they are in the whizzml "organization".
