### PR TITLE
anomaly-benchmarking: added generate-datasets

### DIFF
--- a/anomaly-benchmarking/generate-datasets/metadata.json
+++ b/anomaly-benchmarking/generate-datasets/metadata.json
@@ -1,6 +1,6 @@
 {
-  "name": "Generate datasets",
-  "description": "",
+  "name": "Generate benchmarking datasets",
+  "description": "Creates a suite of benchmark datasets for anomaly detection algorithms",
   "kind": "script",
   "source_code": "script.whizzml",
   "imports": ["../make-binary"],

--- a/anomaly-benchmarking/generate-datasets/metadata.json
+++ b/anomaly-benchmarking/generate-datasets/metadata.json
@@ -1,0 +1,27 @@
+{
+  "name": "Generate datasets",
+  "description": "",
+  "kind": "script",
+  "source_code": "script.whizzml",
+  "imports": ["../make-binary"],
+  "inputs": [
+    {
+      "name": "dataset-list",
+      "type": "list",
+      "description": "The resource ids of the 'mother' datasets"
+    },
+    {
+      "name": "delete-resources",
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to delete all intermediate resources"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "generated-datasets",
+      "type": "list",
+      "description": "generated children datasets"
+    }
+  ]
+}

--- a/anomaly-benchmarking/generate-datasets/readme.md
+++ b/anomaly-benchmarking/generate-datasets/readme.md
@@ -1,0 +1,50 @@
+# Generating Benchmarking Datasets for Anomaly Detection
+
+This script takes a list of datasets and transforms them into a suite
+of ground-truthed benchmark datasets for anomaly detection as laid out
+in the ODD paper
+http://www.outlier-analytics.org/odd13kdd/papers/emmott,das,dietterich,fern,wong.pdf. It depends on the library "make-binary". (See [readme](../make-binary/readme.md))
+
+These output datasets vary along the dimensions point difficulty, relative
+frequency of anomalies, and clusteredness.
+
+For each dataset id in the list, this script: 
+
+- Transforms the dataset into a binary classification using `make-binary`.
+
+- Seperates out the "normal" rows.
+
+- Point difficulty: Models the dataset with a logistic regression, and
+  uses a batchprediciton to labels each row with the probability of it
+  being labeled "normal". The rows labeled "anomalous" are sorted into
+  one of four datasets based on this probability. ("Easy" (0, 0.1666),
+  "medium" [0.1666, 0.3333), "hard" [0.3333, 0.5), "very hard" [0.5,
+  1))
+
+- Clusteredness: For each of the point difficulty datasets, an anomaly
+  detector (isolation forest) and batchprediction are used to label
+  each row with an anomaly score. This is a rough gauge for
+  clusteredness, and new datasets are created from the top and bottom
+  20% anomaly scores. The actual clusteredness is calculated by
+  finding the ratio of the variance of the "normal" rows to the
+  variance of the new dataset (which has N rows). Actual clusteredness
+  is sorted into one of six categories: high scatter (0, 0.25), medium
+  scatter [0.25, 0.5), low scatter [0.5, 1), low clusteredness [1,2),
+  medium clusteredness [2, 4), and high clusteredness [4, infinity).
+
+- Frequency: As long as the dataset has at least 10 rows, a new
+  dataset (which has K rows) is created through a sample rate set to
+  create the goal frequency. Goal frequencies are 0.001, 0.005, 0.01,
+  0.05, and 0.1.
+
+- If enough rows are availible, ten replicate datasets are created at
+  each combination of difficulty, clusteredness, and frequency. A
+  maxiumum of N/K replicates are created.
+
+- These datasets are merged back with the "normal" rows.
+
+- The final output is a list of maps with keys "difficulty",
+  "frequency", "variance", and "resource" (the resource id of the
+  final merged dataset).
+
+If `delete-resources` is true, it deletes all intermediate resources.

--- a/anomaly-benchmarking/generate-datasets/readme.md
+++ b/anomaly-benchmarking/generate-datasets/readme.md
@@ -10,14 +10,15 @@ frequency of anomalies, and clusteredness.
 
 For each dataset id in the list, this script: 
 
-- Transforms the dataset into a binary classification using `make-binary`.
+- Transforms the dataset into a binary classification using the
+  library function `make-binary`.
 
 - Seperates out the "normal" rows.
 
 - Point difficulty: Models the dataset with a logistic regression, and
-  uses a batchprediciton to labels each row with the probability of it
+  uses a batchprediction to labels each row with the probability of it
   being labeled "normal". The rows labeled "anomalous" are sorted into
-  one of four datasets based on this probability. ("Easy" (0, 0.1666),
+  one of four datasets based on this probability. ("easy" (0, 0.1666),
   "medium" [0.1666, 0.3333), "hard" [0.3333, 0.5), "very hard" [0.5,
   1))
 

--- a/anomaly-benchmarking/generate-datasets/script.whizzml
+++ b/anomaly-benchmarking/generate-datasets/script.whizzml
@@ -145,7 +145,7 @@
 
 (define (generate-map ds-id normal-ds)
   (let (ds (fetch ds-id)
-        combined (create-and-wait-dataset {"origin_datasets" [ds-id normal-ds]}) 
+        combined (create-dataset {"origin_datasets" [ds-id normal-ds]}) 
         my-tags (ds "tags"))
     (make-map ["difficulty" "frequency" "variation"  "resource"] 
               (append my-tags combined))))

--- a/anomaly-benchmarking/generate-datasets/script.whizzml
+++ b/anomaly-benchmarking/generate-datasets/script.whizzml
@@ -2,43 +2,48 @@
 
 (define (all-preferred ds-id)
   (let (ds (fetch ds-id)
-        field-list (keys (ds "fields"))
-        not-preferred (filter (lambda (x) (not (get-in ds ["fields" x "preferred"]))) field-list))
-     (update ds-id {"fields" (make-map not-preferred (repeat (count not-preferred) {"preferred" true}))})))
+        field-list (keys (ds "fields")))
+    (update ds-id 
+            {"fields" (make-map field-list (repeat (count field-list) 
+                                                   {"preferred" true}))})))
 
 ;; Given a dataset and a field name, returns the field id with that name
 
 (define (get-id ds name)
-  (let (field (ds "fields"))
-    (head (filter (lambda (x) (= (field [x "name"]) name)) 
-                (keys field)))))
+  (let (fields (ds "fields"))
+    (try
+      (head (filter (lambda (x) (= (fields [x "name"]) name)) 
+                    (keys fields)))
+      (catch e
+        (log-warn "Could not find field name " name " : " e)))))
 
 ;; Given a binary dataset, finds the point difficulty of each row and
-;; returns an dataset of only anomalous points and a new field
+;; returns a dataset of only anomalous points and a new field
 ;; labeling each row by one of four difficulty levels.
 
-(define (point-difficulty ds-id delete-resources)
+(define (point-difficulty ds-id new-obj delete-resources)
   (let (ds (all-preferred ds-id)
-        lr-id (create-and-wait-logisticregression {"dataset" ds})
-        lr-fields ((fetch lr-id) "input_fields")
-        bp-id (create-and-wait-batchprediction {"logisticregression" lr-id 
-                                       "dataset" ds 
-                                       "probabilities" true 
-                                       "output_dataset" true 
-                                       "output_fields" lr-fields })
+        lr-id (create-and-wait-logisticregression ds)
+        bp-id (wait (create-batchprediction lr-id ds {"probabilities" true 
+                                                      "output_dataset" true 
+                                                      "all_fields" true }))
         prob-ds-id ((fetch bp-id) "output_dataset_resource")
-        prob-ds (fetch prob-ds-id)
+        prob-ds (fetch (wait prob-ds-id))
         norm-field (get-id prob-ds "normal probability")
         ano-field (get-id prob-ds "anomalous probability")
-        obj-field (get-id prob-ds "Is Anomaly?")
-        difficulty-sorter (lambda (diff-id) (flatline "(segment-label {{diff-id}} \"easy\" 0.133333 \"medium\" 0.333333 \"hard\" 0.5 \"very hard\")"))
-        diff-ds (create-and-wait-dataset {"origin_dataset" prob-ds-id
-                  "lisp_filter" (flatline "(= (field {{obj-field}}) \"anomalous\")")
-                  "new_fields" [{"field" (difficulty-sorter norm-field)
-                                 "name" "sorted"}]
-                  "all_but" [norm-field ano-field]}))
+        diff-sort (flatline "(segment-label {{norm-field}}" 
+                            "               \"easy\" 0.133333"
+                            "               \"medium\" 0.333333"
+                            "               \"hard\" 0.5"
+                            "               \"very hard\")")
+        my-filter (flatline "(= (field {{new-obj}}) \"anomalous\")")
+        diff-ds (wait (create-dataset prob-ds-id 
+                                      {"lisp_filter" my-filter
+                                       "new_fields" [{"field" diff-sort
+                                                      "name" "sorted"}]
+                                       "all_but" [norm-field ano-field]})))
     (when delete-resources
-          (map safe-delete [lr-id bp-id prob-ds-id]))
+      (map safe-delete [lr-id bp-id prob-ds-id]))
     diff-ds))
 
 ;; Takes a dataset labeled by point-difficulty, and splits the dataset
@@ -49,17 +54,18 @@
   (let (ds (fetch ds-id)
         split-field (get-id ds "sorted")
         split-list (ds ["fields" split-field "summary" "categories"]) 
-        split-map (make-map (map (lambda (x) (head x)) split-list) 
-                            (map (lambda (x) (last x)) split-list))
+        split-map (make-map (map head split-list)(map last split-list))
         split-it (lambda (level)
-                 (if (contains? split-map level) 
-                   (create-and-wait-dataset {"origin_dataset" ds-id
-                     "lisp_filter" (flatline "(= (field {{split-field}}) {{level}})")
-                     "excluded_fields" [split-field]
-                     "name" (str level " difficulty")
-                     "tags" [level]})
-                   false)))
-    (for (x ["easy" "medium" "hard" "very hard"]) (split-it x))))
+                   (let (my-filter (flatline "(= (f {{split-field}})" 
+                                             "   {{level}})"))
+                     (if (contains? split-map level) 
+                       (wait (create-dataset {"origin_dataset" ds-id
+                                              "lisp_filter" my-filter
+                                              "excluded_fields" [split-field]
+                                              "name" (str level " diff")
+                                              "tags" [level]}))
+                       false))))
+    (map split-it ["easy" "medium" "hard" "very hard"])))
 
 ;; Takes a dataset and creates two datasets, one from the lowest
 ;; anomaly scores and one from the highest. Returns a list of the
@@ -70,24 +76,26 @@
         ds-name (ds "name")
         ad-id (create-anomaly {"dataset" ds-id
                                "id_fields" [obj-field]})
-        bas-id (create-batchanomalyscore {"anomaly" (wait ad-id)
+        bas-id (create-batchanomalyscore {"anomaly" ad-id
                                           "dataset" ds-id
                                           "all_fields" true
                                           "output_dataset" true})
         score-ds ((fetch (wait bas-id)) "output_dataset_resource")
-        id (get-id (fetch score-ds) "score")
+        id (get-id (fetch (wait score-ds)) "score")
         score-low (flatline "(within-percentiles? {{id}} 0 0.2)")
         score-high (flatline "(within-percentiles? {{id}} 0.8 1)")
         low-ds (create-and-wait-dataset {"origin_dataset" score-ds
-                                "lisp_filter" score-low
-                                "name" (str ds-name " - high clusteredness")
-                                "excluded_fields" [id]})
+                                         "lisp_filter" score-low
+                                         "name" (str ds-name 
+                                                     " - high clusteredness")
+                                         "excluded_fields" [id]})
         high-ds (create-and-wait-dataset {"origin_dataset" score-ds
-                                 "lisp_filter" score-high
-                                 "name" (str ds-name " - low clusteredness")
-                                 "excluded_fields" [id]}))
+                                          "lisp_filter" score-high
+                                          "name" (str ds-name 
+                                                      " - low clusteredness")
+                                          "excluded_fields" [id]}))
     (when delete-resources
-          (map safe-delete [ad-id bas-id score-ds]))
+      (map safe-delete [ad-id bas-id score-ds]))
     [low-ds high-ds]))
 
 ;; Takes two datasets, one normal and one anomalous. Finds the
@@ -101,9 +109,9 @@
   (let (ano-ds (fetch ano-ds-id)
         my-tags (ano-ds "tags")
         ano-cl-id (create-and-wait-cluster {"dataset" ano-ds-id 
-                                   "k" 1 
-                                   "balance_fields" false 
-                                   "field_scales" norm-scales})
+                                            "k" 1 
+                                            "balance_fields" false 
+                                            "field_scales" norm-scales})
         ano-var ((fetch ano-cl-id) ["clusters"
                                     "global"
                                     "distance"
@@ -116,7 +124,7 @@
                       (< my-ratio 4) "medium clusteredness"
                       "high clusteredness"))
     (when delete-resources
-          (map safe-delete [ano-cl-id]))
+      (map safe-delete [ano-cl-id]))
     (update ano-ds-id {"tags" (append my-tags new-tag)})))
 
 ;; Takes a dataset. Determines which relative frequencies are
@@ -125,18 +133,21 @@
 
 (define (relative-frequency ds-id normal-rows)
   (let (ds (fetch ds-id)
-        availible-rows (ds "rows")
+        rows (ds "rows")
         ds-name (ds "name")
         my-tags (ds "tags")
-        max-freq (/ availible-rows (+ availible-rows normal-rows)))
+        max-freq (/ rows (+ rows normal-rows)))
     (for (freq [0.001 0.005 0.01 0.05 0.1])
       (let (k (/ (* freq normal-rows) (- 1 freq)))
         (when (> max-freq freq)
-              (repeatedly (min 10 (floor (/ availible-rows k))) 
-                          (lambda () (create-dataset {"origin_dataset" ds-id
-                                       "sample_rate" (/ k availible-rows)
-                                       "name" (str ds-name " - " freq)
-                                       "tags" (append my-tags (str freq))}))))))))
+          (repeatedly (min 10 (floor (/ rows k))) 
+                      (lambda () (create-dataset {"origin_dataset" ds-id
+                                                  "sample_rate" (/ k rows)
+                                                  "name" (str ds-name 
+                                                              " - " 
+                                                              freq)
+                                                  "tags" (append my-tags 
+                                                                 (str freq))}))))))))
   
 ;; Given an anomalous dataset and a normal dataset, combines them into
 ;; a single dataset, and returns a map with key/value pairs from the
@@ -162,10 +173,10 @@
   (let (old-obj ((fetch ds-id) ["objective_field" "id"])
         binary (make-binary ds-id old-obj delete-resources)
         new-obj ((fetch binary) ["objective_field" "id"])
+        norm-filter (flatline "(= (field {{new-obj}}) \"normal\")")
         normal-ds (create-and-wait-dataset {"origin_dataset" binary
-                    "lisp_filter" 
-                    (flatline "(= (field {{new-obj}}) \"normal\")")
-                    "name" "normal"})
+                                            "lisp_filter" norm-filter
+                                            "name" "normal"})
         normal-rows ((fetch normal-ds) "rows")
         norm-cl-id (create-and-wait-cluster {"dataset" normal-ds "k" 1})
         norm-cl (fetch norm-cl-id)
@@ -174,31 +185,34 @@
                            "distance" 
                            "standard_deviation"])
         norm-scales (norm-cl "scales")
-        diff-ds (point-difficulty binary delete-resources)
+        diff-ds (point-difficulty binary new-obj delete-resources)
         difficulty-list (filter (lambda (x) x) (split-difficulty diff-ds))
         variation-list (flatten [] 
                                 (for (x difficulty-list)
-                                  (if x (semantic-variation x 
-                                                            new-obj 
+                                  (when x 
+                                    (semantic-variation x 
+                                                        new-obj 
                                                         delete-resources)))) 
         frequency-list (flatten []
                                 (for (x variation-list)
-                                  (if x (relative-frequency x normal-rows))))
+                                  (when x 
+                                    (relative-frequency x normal-rows))))
         labeled-by-variation (for (x frequency-list)
-                               (if x (variance-ratios x 
-                                                      norm-var 
-                                                      norm-scales 
-                                                      delete-resources))) 
+                               (when x 
+                                 (variance-ratios x 
+                                                  norm-var 
+                                                  norm-scales 
+                                                  delete-resources))) 
         final-list (for (x labeled-by-variation)
                      (if x (generate-map x normal-ds))))
     (when delete-resources
-          (map safe-delete (flatten [] [binary
-                                        normal-ds
-                                        norm-cl-id
-                                        diff-ds 
-                                        difficulty-list 
-                                        variation-list
-                                        frequency-list])))
+      (map safe-delete (flatten [] [binary
+                                    normal-ds
+                                    norm-cl-id
+                                    diff-ds 
+                                    difficulty-list 
+                                    variation-list
+                                    frequency-list])))
     (filter (lambda (x) x) final-list)))
 
 (define generated-datasets

--- a/anomaly-benchmarking/generate-datasets/script.whizzml
+++ b/anomaly-benchmarking/generate-datasets/script.whizzml
@@ -1,0 +1,205 @@
+;; Takes a dataset, returns the same dataset with all fields marked preferred
+
+(define (all-preferred ds-id)
+  (let (ds (fetch ds-id)
+        field-list (keys (ds "fields"))
+        not-preferred (filter (lambda (x) (not (get-in ds ["fields" x "preferred"]))) field-list))
+     (update ds-id {"fields" (make-map not-preferred (repeat (count not-preferred) {"preferred" true}))})))
+
+;; Given a dataset and a field name, returns the field id with that name
+
+(define (get-id ds name)
+  (let (field (ds "fields"))
+    (head (filter (lambda (x) (= (field [x "name"]) name)) 
+                (keys field)))))
+
+;; Given a binary dataset, finds the point difficulty of each row and
+;; returns an dataset of only anomalous points and a new field
+;; labeling each row by one of four difficulty levels.
+
+(define (point-difficulty ds-id delete-resources)
+  (let (ds (all-preferred ds-id)
+        lr-id (create-and-wait-logisticregression {"dataset" ds})
+        lr-fields ((fetch lr-id) "input_fields")
+        bp-id (create-and-wait-batchprediction {"logisticregression" lr-id 
+                                       "dataset" ds 
+                                       "probabilities" true 
+                                       "output_dataset" true 
+                                       "output_fields" lr-fields })
+        prob-ds-id ((fetch bp-id) "output_dataset_resource")
+        prob-ds (fetch prob-ds-id)
+        norm-field (get-id prob-ds "normal probability")
+        ano-field (get-id prob-ds "anomalous probability")
+        obj-field (get-id prob-ds "Is Anomaly?")
+        difficulty-sorter (lambda (diff-id) (flatline "(segment-label {{diff-id}} \"easy\" 0.133333 \"medium\" 0.333333 \"hard\" 0.5 \"very hard\")"))
+        diff-ds (create-and-wait-dataset {"origin_dataset" prob-ds-id
+                  "lisp_filter" (flatline "(= (field {{obj-field}}) \"anomalous\")")
+                  "new_fields" [{"field" (difficulty-sorter norm-field)
+                                 "name" "sorted"}]
+                  "all_but" [norm-field ano-field]}))
+    (when delete-resources
+          (map safe-delete [lr-id bp-id prob-ds-id]))
+    diff-ds))
+
+;; Takes a dataset labeled by point-difficulty, and splits the dataset
+;; into one of four new datasets based on their label. Returns the
+;; list of these new datasets.
+
+(define (split-difficulty ds-id)
+  (let (ds (fetch ds-id)
+        split-field (get-id ds "sorted")
+        split-list (ds ["fields" split-field "summary" "categories"]) 
+        split-map (make-map (map (lambda (x) (head x)) split-list) 
+                            (map (lambda (x) (last x)) split-list))
+        split-it (lambda (level)
+                 (if (contains? split-map level) 
+                   (create-and-wait-dataset {"origin_dataset" ds-id
+                     "lisp_filter" (flatline "(= (field {{split-field}}) {{level}})")
+                     "excluded_fields" [split-field]
+                     "name" (str level " difficulty")
+                     "tags" [level]})
+                   false)))
+    (for (x ["easy" "medium" "hard" "very hard"]) (split-it x))))
+
+;; Takes a dataset and creates two datasets, one from the lowest
+;; anomaly scores and one from the highest. Returns a list of the
+;; dataset ids.
+
+(define (semantic-variation ds-id obj-field delete-resources)
+  (let (ds (fetch ds-id)
+        ds-name (ds "name")
+        ad-id (create-anomaly {"dataset" ds-id
+                               "id_fields" [obj-field]})
+        bas-id (create-batchanomalyscore {"anomaly" (wait ad-id)
+                                          "dataset" ds-id
+                                          "all_fields" true
+                                          "output_dataset" true})
+        score-ds ((fetch (wait bas-id)) "output_dataset_resource")
+        id (get-id (fetch score-ds) "score")
+        score-low (flatline "(within-percentiles? {{id}} 0 0.2)")
+        score-high (flatline "(within-percentiles? {{id}} 0.8 1)")
+        low-ds (create-and-wait-dataset {"origin_dataset" score-ds
+                                "lisp_filter" score-low
+                                "name" (str ds-name " - high clusteredness")
+                                "excluded_fields" [id]})
+        high-ds (create-and-wait-dataset {"origin_dataset" score-ds
+                                 "lisp_filter" score-high
+                                 "name" (str ds-name " - low clusteredness")
+                                 "excluded_fields" [id]}))
+    (when delete-resources
+          (map safe-delete [ad-id bas-id score-ds]))
+    [low-ds high-ds]))
+
+;; Takes two datasets, one normal and one anomalous. Finds the
+;; variance of each dataset, calculates the ratio of normal variance
+;; to anomalous variance, sorts the ratio into one of six categories,
+;; and tags the anomalous dataset with that category. The variance is
+;; found by abusing k-means; it creates just one cluster which contains
+;; all the data.
+
+(define (variance-ratios ano-ds-id norm-var norm-scales delete-resources)
+  (let (ano-ds (fetch ano-ds-id)
+        my-tags (ano-ds "tags")
+        ano-cl-id (create-and-wait-cluster {"dataset" ano-ds-id 
+                                   "k" 1 
+                                   "balance_fields" false 
+                                   "field_scales" norm-scales})
+        ano-var ((fetch ano-cl-id) ["clusters"
+                                    "global"
+                                    "distance"
+                                    "standard_deviation"])
+        my-ratio (pow (/ norm-var ano-var) 2)
+        new-tag (cond (< my-ratio 0.25) "high scatter"
+                      (< my-ratio 0.5) "medium scatter"
+                      (< my-ratio 1) "low scatter"
+                      (< my-ratio 2) "low clusteredness"
+                      (< my-ratio 4) "medium clusteredness"
+                      "high clusteredness"))
+    (when delete-resources
+          (map safe-delete [ano-cl-id]))
+    (update ano-ds-id {"tags" (append my-tags new-tag)})))
+
+;; Takes a dataset. Determines which relative frequencies are
+;; possible. Generates the max possible datasets (limit 40) at those
+;; frequencies. Returns a list of datasets.
+
+(define (relative-frequency ds-id normal-rows)
+  (let (ds (fetch ds-id)
+        availible-rows (ds "rows")
+        ds-name (ds "name")
+        my-tags (ds "tags")
+        max-freq (/ availible-rows (+ availible-rows normal-rows)))
+    (for (freq [0.001 0.005 0.01 0.05 0.1])
+      (let (k (/ (* freq normal-rows) (- 1 freq)))
+        (when (> max-freq freq)
+              (repeatedly (min 10 (floor (/ availible-rows k))) 
+                          (lambda () (create-dataset {"origin_dataset" ds-id
+                                       "sample_rate" (/ k availible-rows)
+                                       "name" (str ds-name " - " freq)
+                                       "tags" (append my-tags (str freq))}))))))))
+  
+;; Given an anomalous dataset and a normal dataset, combines them into
+;; a single dataset, and returns a map with key/value pairs from the
+;; tags from the anomalous dataset (difficulty, frequency, and
+;; variation) and the combined dataset (resource)
+
+(define (generate-map ds-id normal-ds)
+  (let (ds (fetch ds-id)
+        combined (create-and-wait-dataset {"origin_datasets" [ds-id normal-ds]}) 
+        my-tags (ds "tags"))
+    (make-map ["difficulty" "frequency" "variation"  "resource"] 
+              (append my-tags combined))))
+
+;; Putting it all together. This function takes a dataset, makes the
+;; dataset binary using the make-binary library, and splits it into
+;; parts by point-difficulty, creates a high and low clusteredness for
+;; each part, and generates as many frequencies as possible for each
+;; clusteredness. Returns a list of maps for all the datasets created,
+;; specifying the resource id, difficulty, semantic variation, and
+;; frequency.
+
+(define (generate ds-id delete-resources)
+  (let (old-obj ((fetch ds-id) ["objective_field" "id"])
+        binary (make-binary ds-id old-obj delete-resources)
+        new-obj ((fetch binary) ["objective_field" "id"])
+        normal-ds (create-and-wait-dataset {"origin_dataset" binary
+                    "lisp_filter" 
+                    (flatline "(= (field {{new-obj}}) \"normal\")")
+                    "name" "normal"})
+        normal-rows ((fetch normal-ds) "rows")
+        norm-cl-id (create-and-wait-cluster {"dataset" normal-ds "k" 1})
+        norm-cl (fetch norm-cl-id)
+        norm-var (norm-cl ["clusters" 
+                           "global" 
+                           "distance" 
+                           "standard_deviation"])
+        norm-scales (norm-cl "scales")
+        diff-ds (point-difficulty binary delete-resources)
+        difficulty-list (filter (lambda (x) x) (split-difficulty diff-ds))
+        variation-list (flatten [] 
+                                (for (x difficulty-list)
+                                  (if x (semantic-variation x 
+                                                            new-obj 
+                                                        delete-resources)))) 
+        frequency-list (flatten []
+                                (for (x variation-list)
+                                  (if x (relative-frequency x normal-rows))))
+        labeled-by-variation (for (x frequency-list)
+                               (if x (variance-ratios x 
+                                                      norm-var 
+                                                      norm-scales 
+                                                      delete-resources))) 
+        final-list (for (x labeled-by-variation)
+                     (if x (generate-map x normal-ds))))
+    (when delete-resources
+          (map safe-delete (flatten [] [binary
+                                        normal-ds
+                                        norm-cl-id
+                                        diff-ds 
+                                        difficulty-list 
+                                        variation-list
+                                        frequency-list])))
+    (filter (lambda (x) x) final-list)))
+
+(define generated-datasets
+  (for (x dataset-list) (generate x delete-resources)))

--- a/anomaly-benchmarking/make-binary/library.whizzml
+++ b/anomaly-benchmarking/make-binary/library.whizzml
@@ -10,20 +10,26 @@
 ;; new field "Is Anomoly?" with values "anomalous" and "normal" based on
 ;; the original classes
 
-(define (two-to-binary ds)
+(define (two-to-binary ds field-id)
   (let (my-ds (fetch ds)
-       field-id (get-in my-ds ["objective_field" "id"])
-       anomalous (head 
-                   (head (get-in my-ds 
-                                 ["fields" 
-                                  field-id 
-                                  "summary" 
-                                  "categories"]))))
-    (create-dataset {"origin_dataset" ds
-                     "new_fields" [{"field" (two-class-filter 
-                                             field-id 
-                                             anomalous)
-                                    "name" "Is Anomaly?"}]})))
+        field-id (my-ds ["objective_field" "id"])
+        my-name (my-ds "name")
+        anomalous (head (head (my-ds ["fields" 
+                                      field-id 
+                                      "summary" 
+                                      "categories"]))))
+    (create-and-wait-dataset {"origin_dataset" ds
+                              "new_fields" [{"field" (two-class-filter 
+                                                      field-id 
+                                                      anomalous)
+                                             "name" "Is Anomaly?"}]
+                              "all_but" [field-id]
+                              "name" (str my-name " child")})))
+
+;; Delete resources ignoring errors
+(define (safe-delete id)
+  (if id (delete id)))
+;;       (catch e (log-info (str "Error deleting resource " id " ignored")))))
 
 ;; Multi-to-Binary
 
@@ -44,11 +50,13 @@
 ;; Creates a model with 80% of the input dataset, evaluates it
 ;; with the remaining 20%. Returns the evaluation id.
 
-(define (evaluate-model-on-dataset ds-id)
+(define (evaluate-model-on-dataset ds-id delete-resources)
   (let (training-id (sample-dataset ds-id 0.8 false)
         test-id (sample-dataset ds-id 0.8 true)
         model-id (create-model {"dataset" training-id "randomize" true})
         ev-id (create-and-wait-evaluation {"model" model-id "dataset" test-id}))
+    (when delete-resources
+          (map safe-delete [training-id test-id model-id]))
      ev-id))
 
 ;; Graphs
@@ -220,17 +228,19 @@
 ;; either "normal" or "anomalous", determined by the two-colored graph
 ;; of the confusion matrix
 
-(define (multi-to-binary ds)
-  (let (my-eval (evaluate-model-on-dataset ds)
+(define (multi-to-binary ds field-id delete-resources)
+  (let (my-eval (evaluate-model-on-dataset ds delete-resources)
        my-graph (make-graph my-eval)
        my-span-tree (max-span-tree my-graph)
        colored-graph (two-color my-graph my-span-tree)
-       field-id (get (fetch ds) "objective_field")
        color-map (mapify (get colored-graph "nodes") "name" "color")
-       filter (color-filter (get field-id "id") color-map))
-    (create-dataset {"origin_dataset" ds
-                     "new_fields" [{"field" filter
-                                    "name" "Is Anomaly?"}]})))
+       my-filter (color-filter field-id color-map))
+    (when delete-resources
+          (safe-delete my-eval))
+    (create-and-wait-dataset {"origin_dataset" ds
+                             "new_fields" [{"field" my-filter
+                                            "name" "Is Anomaly?"}]
+                              "all_but" [field-id]})))
 
 ;; Numeric-to-Binary
 
@@ -246,22 +256,21 @@
 ;; "normal" based on whether the value of the objective field is above
 ;; or below the median
 
-(define (numeric-to-binary ds)
+(define (numeric-to-binary ds field-id)
   (let (my-ds (fetch ds)
-        field-id (get-in my-ds ["objective_field" "id"])
-        median (get-in my-ds ["fields" field-id "summary" "median"])
+        median (my-ds ["fields" field-id "summary" "median"])
         filter (median-filter field-id median))
-    (create-dataset {"origin_dataset" ds
-                     "new_fields" [{"field" filter
-                                    "name" "Is Anomaly?"}]})))
+    (create-and-wait-dataset {"origin_dataset" ds
+                              "new_fields" [{"field" filter
+                                             "name" "Is Anomaly?"}]
+                              "all_but" [field-id]})))
 
-;; Given a dataset, determines which function to use and returns the
-;; appropriate extended dataset
+;; Given a dataset and the field id of its objective, determines which
+;; function to use and returns the appropriate extended dataset
 
-(define (make-binary ds)
+(define (make-binary ds field-id delete-resources)
   (let (my-ds (fetch ds)
-        field-id (get-in my-ds ["objective_field" "id"])
-        my-optype (get-in my-ds ["fields" field-id "optype"]))
+        my-optype (my-ds ["fields" field-id "optype"]))
     (if (= my-optype "categorical")
       (let (classes (count (get-in my-ds 
                                  ["fields" 
@@ -269,8 +278,6 @@
                                   "summary" 
                                   "categories"])))
         (if (= classes 2)
-          (two-to-binary ds)
-          (multi-to-binary ds)))
-      (numeric-to-binary ds))))                                
-
-(define binary-dataset (make-binary dataset-id))
+          (two-to-binary ds field-id)
+          (multi-to-binary ds field-id delete-resources)))
+      (numeric-to-binary ds field-id))))                                

--- a/anomaly-benchmarking/make-binary/library.whizzml
+++ b/anomaly-benchmarking/make-binary/library.whizzml
@@ -4,7 +4,9 @@
 ;; categorizes datapoints as "anomalous" or "normal"
 
 (define (two-class-filter id anomalous)
-  (flatline "(if (matches? (field {{id}}) {{anomalous}}) \"anomalous\" \"normal\")"))
+  (flatline "(if (matches? (field {{id}}) {{anomalous}})"
+            "   \"anomalous\""
+            "   \"normal\")"))
 
 ;; Given a dataset with an objective field with two classes, adds on a
 ;; new field "Is Anomoly?" with values "anomalous" and "normal" based on
@@ -22,14 +24,13 @@
                               "new_fields" [{"field" (two-class-filter 
                                                       field-id 
                                                       anomalous)
-                                             "name" "Is Anomaly?"}]
+                                             "name" "instance type"}]
                               "all_but" [field-id]
                               "name" (str my-name " child")})))
 
 ;; Delete resources ignoring errors
 (define (safe-delete id)
-  (if id (delete id)))
-;;       (catch e (log-info (str "Error deleting resource " id " ignored")))))
+  (when id (delete id)))
 
 ;; Multi-to-Binary
 
@@ -56,7 +57,7 @@
         model-id (create-model {"dataset" training-id "randomize" true})
         ev-id (create-and-wait-evaluation {"model" model-id "dataset" test-id}))
     (when delete-resources
-          (map safe-delete [training-id test-id model-id]))
+      (map safe-delete [training-id test-id model-id]))
      ev-id))
 
 ;; Graphs
@@ -224,7 +225,7 @@
     (join " " ["(cond" conditions ")"])))
 
 ;; Given a dataset with a multivariate objective field, returns an
-;; extended dataset with a new field "Is Anomaly?", which can be
+;; extended dataset with a new field "instance type", which can be
 ;; either "normal" or "anomalous", determined by the two-colored graph
 ;; of the confusion matrix
 
@@ -236,10 +237,10 @@
        color-map (mapify (get colored-graph "nodes") "name" "color")
        my-filter (color-filter field-id color-map))
     (when delete-resources
-          (safe-delete my-eval))
+      (safe-delete my-eval))
     (create-and-wait-dataset {"origin_dataset" ds
                              "new_fields" [{"field" my-filter
-                                            "name" "Is Anomaly?"}]
+                                            "name" "instance type"}]
                               "all_but" [field-id]})))
 
 ;; Numeric-to-Binary
@@ -252,7 +253,7 @@
   (flatline "(if (> (field {{id}}) {{median}}) \"anomalous\" \"normal\")"))
 
 ;; Given a dataset with a numeric objective field, returns an extended
-;; dataset with a new field "binary" with values "anomalous" and
+;; dataset with a new field "instance type" with values "anomalous" and
 ;; "normal" based on whether the value of the objective field is above
 ;; or below the median
 
@@ -262,7 +263,7 @@
         filter (median-filter field-id median))
     (create-and-wait-dataset {"origin_dataset" ds
                               "new_fields" [{"field" filter
-                                             "name" "Is Anomaly?"}]
+                                             "name" "instance type"}]
                               "all_but" [field-id]})))
 
 ;; Given a dataset and the field id of its objective, determines which

--- a/anomaly-benchmarking/make-binary/metadata.json
+++ b/anomaly-benchmarking/make-binary/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Make binary",
-  "description": "",
+  "description": "Turns any dataset into one with a binary objective field",
   "kind": "library",
   "source_code": "library.whizzml"
 }

--- a/anomaly-benchmarking/make-binary/metadata.json
+++ b/anomaly-benchmarking/make-binary/metadata.json
@@ -1,0 +1,6 @@
+{
+  "name": "Make binary",
+  "description": "",
+  "kind": "library",
+  "source_code": "library.whizzml"
+}

--- a/anomaly-benchmarking/make-binary/readme.md
+++ b/anomaly-benchmarking/make-binary/readme.md
@@ -1,0 +1,41 @@
+# Making a Dataset Binary
+
+This library takes any dataset and returns it extended by a new field,
+"Is Anomaly?". "Is Anomaly?" takes the values "normal" or "anomalous"
+following the procedure laid out in the ODD paper
+http://www.outlier-analytics.org/odd13kdd/papers/emmott,das,dietterich,fern,wong.pdf.
+
+Given a dataset id, the field id of its objective, and the boolean
+`delete-resources`, it:
+
+- Determines whether the dataset is a regression, a classifications
+  with two classes, or a classifications with multiple classes.
+
+- If it is a regression, it assigns points greater than the median of
+  the regression response as "anomalous" and those lower "normal".
+
+- If it is a two-class classification, it assigns points with a class
+  like the first row as "anomalous" and those with the other class
+  "normal".
+
+- If it is a multi-class classification, it:
+
+  - Creates evaluation of that dataset using a random forest.  
+
+  - Takes the confusion matrix of that evaluation, and creates a graph
+    where the nodes are the classes of the confusion matrix and the
+    edges (with ends j and k) have weights equal to the sum of the
+    cells [j k] and [k j]. (Note: While the ODD paper uses a confusion
+    matrix of probabilities, the BigML confusion matrix gives straight
+    counts.)
+
+  - Creates a maximum spanning tree of that graph, thus finding the
+    "most-confusable" classes.
+
+  - Two-colors that graph with "normal" and "anomalous".
+
+  - Returns an extended dataset with the new field "Is Anomaly?",
+    determined by the coloring of the class in the old objective
+    field.
+
+- If `delete-resources` is true, it deletes all intermediate resources.

--- a/anomaly-benchmarking/make-binary/readme.md
+++ b/anomaly-benchmarking/make-binary/readme.md
@@ -1,15 +1,15 @@
 # Making a Dataset Binary
 
 This library takes any dataset and returns it extended by a new field,
-"Is Anomaly?". "Is Anomaly?" takes the values "normal" or "anomalous"
+"instance type". This field takes the values "normal" or "anomalous"
 following the procedure laid out in the ODD paper
 http://www.outlier-analytics.org/odd13kdd/papers/emmott,das,dietterich,fern,wong.pdf.
 
 Given a dataset id, the field id of its objective, and the boolean
 `delete-resources`, it:
 
-- Determines whether the dataset is a regression, a classifications
-  with two classes, or a classifications with multiple classes.
+- Determines whether the dataset is a regression, a classification
+  with two classes, or a classification with multiple classes.
 
 - If it is a regression, it assigns points greater than the median of
   the regression response as "anomalous" and those lower "normal".
@@ -34,7 +34,7 @@ Given a dataset id, the field id of its objective, and the boolean
 
   - Two-colors that graph with "normal" and "anomalous".
 
-  - Returns an extended dataset with the new field "Is Anomaly?",
+  - Returns an extended dataset with the new field "instance type",
     determined by the coloring of the class in the old objective
     field.
 

--- a/anomaly-benchmarking/metadata.json
+++ b/anomaly-benchmarking/metadata.json
@@ -1,20 +1,9 @@
 {
-  "name": "Multivariate to Binary",
-  "description": "Turns a multivariate classification dataset into a binary one",
-  "kind": "script",
-  "source_code": "script.whizzml",
-  "inputs": [
-      {
-          "name": "dataset-id",
-          "type": "dataset-id",
-          "description": "Dataset to be transformed"
-      }
-  ],
-  "outputs": [
-      {
-          "name": "binary-dataset",
-          "type": "dataset-id",
-          "description": "Extended binary dataset"
-      }
+  "name": "Anomaly benchmarking",
+  "description": "",
+  "kind": "package",
+  "components": [
+      "make-binary",
+      "generate-datasets"
   ]
 }

--- a/anomaly-benchmarking/metadata.json
+++ b/anomaly-benchmarking/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Anomaly benchmarking",
-  "description": "",
+  "description": "Creates a suite of datasets for benchmarking anomaly detectors",
   "kind": "package",
   "components": [
       "make-binary",

--- a/anomaly-benchmarking/readme.md
+++ b/anomaly-benchmarking/readme.md
@@ -1,38 +1,36 @@
-# Making a Dataset Binary
+# Generating Benchmarking Datasets for Anomaly Detection
 
-This script takes any dataset and returns it extended by a new field,
-"Is Anomaly?". "Is Anomaly?" takes the values "normal" or "anomalous" following
-the procedure laid out in the ODD paper
-http://www.outlier-analytics.org/odd13kdd/papers/emmott,das,dietterich,fern,wong.pdf.
+This package takes a list of datasets and transforms them into a suite
+of ground-truthed benchmark datasets for anomaly detection as laid out
+in the ODD paper
+http://www.outlier-analytics.org/odd13kdd/papers/emmott,das,dietterich,fern,wong.pdf. It
+is composed of the script "generate-datasets" and the library
+"make-binary". (See readmes:
+[generate-datasets](/generate-datasets/readme.md) and
+[make-binary](/make-binary/readme.md))
 
-Given a dataset id, it:
+These output datasets vary along the following dimensions:
 
-- Determines whether the dataset is a regression, a classifications
-  with two classes, or a classifications with multiple classes.
+(a) point difficulty ("easy" (0, 0.1666), "medium" [0.1666, 0.3333),
+"hard" [0.3333, 0.5), "very hard" [0.5, 1),
 
-- If it is a regression, it assigns points greater than the median of
-  the regression response as "anomalous" and those lower "normal".
+(b) relative frequency of anomalies (0.001, 0.005, 0.01, 0.05, and
+0.1), and
 
-- If it is a two-class classification, it assigns points with a class
-  like the first row as "anomalous" and those with the other class
-  "normal".
+(c) clusteredness (high scatter (0, 0.25), medium scatter [0.25, 0.5),
+low scatter [0.5, 1), low clusteredness [1,2), medium clusteredness
+[2, 4), and high clusteredness [4, infinity)).
 
-- If it is a multi-class classification, it:
+# Inputs
 
-  - Creates evaluation of that dataset using a random forest.  
+- A list of dataset resource ids to be used as the "mother" sets for
+  generation.
 
-  - Takes the confusion matrix of that evaluation, and creates a graph
-    where the nodes are the classes of the confusion matrix and the
-    edges (with ends j and k) have weights equal to the sum of the
-    cells [j k] and [k j]. (Note: While the ODD paper uses a confusion
-    matrix of probabilities, the BigML confusion matrix gives straight
-    counts.)
+- A boolean delete-resources to indicate whether intermediate
+  resources should be deleted. (Default is true.)
 
-  - Creates a maximum spanning tree of that graph, thus finding the
-    "most-confusable" classes.
+# How to Install
 
-  - Two-colors that graph with "normal" and "anomalous".
+Please see the [top-level readme](../readme.md) for WhizzML package
+installation instructions.
 
-  - Returns an extended dataset with the new field "Is Anomaly?",
-    determined by the coloring of the class in the old objective
-    field.

--- a/anomaly-benchmarking/test/test.sh
+++ b/anomaly-benchmarking/test/test.sh
@@ -7,39 +7,33 @@ rm -f -R cmd
 rm -f -R .build
 
 log "-------------------------------------------------------"
-log "Test for make-binary script"
+log "Test for anomaly-benchmarking package"
 run_bigmler whizzml --package-dir ../ --output-dir ./.build
 # creating the resources needed to run the test
-run_bigmler --train https://archive.ics.uci.edu/ml/machine-learning-databases/car/car.data --no-model \
-            --project "Whizzml examples tests" --output-dir cmd/pre_test
 run_bigmler --train https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data --no-model \
             --project "Whizzml examples tests" --output-dir cmd/pre_test
-run_bigmler --train https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data --no-model \
-            --project "Whizzml examples tests" --output-dir cmd/pre_test
-
-
 
 # building the inputs for the test
-prefix='[["dataset-id", "'
-suffix='"]]'
+prefix='[["dataset-list", ["'
+suffix='"]]]'
 text=''
 cat cmd/pre_test/dataset | while read dataset
 do
 echo "$prefix$dataset$suffix" > "test_inputs.json"
 done
-log "Testing make-binary script -------------------------------"
+log "Testing generate-datasets script -------------------------------"
 # running the execution with the given inputs
-run_bigmler execute --scripts .build/scripts --inputs test_inputs.json \
+run_bigmler execute --scripts .build/generate-datasets/scripts --inputs test_inputs.json \
                     --output-dir cmd/results
 # check the outputs
 declare file="cmd/results/whizzml_results.json"
-declare regex="\"outputs\": \[\[\"binary-dataset\", "
+declare regex="\"outputs\": \[\[\"generated-datasets\", "
 declare file_content=$( cat "${file}" )
 if [[ " $file_content " =~ $regex ]]
     then
-        log "multi-to-binary OK"
+        log "generate-datasets OK"
     else
-        echo "multi-to-binary KO:\n $file_content"
+        echo "generate-datasets KO:\n $file_content"
         exit 1
 fi
 # remove the created resources


### PR DESCRIPTION
Here is the working implementation of the ODD paper. I made one minor change from the paper -- this script creates ten replicate datasets instead of 40. Special thanks to @charleslparker, for his resource deletion in the clean-data example.

Of note, I was running into some problems with queueing up too many datasets at once. This was "solved" by using `create-and-wait-dataset` even though I don't need to rely on that resource to continue.  It would be nice to not have to worry about parallelization when writing a whizzml script. 