### PR TITLE
Improved test and added user-defined dimension categories

### DIFF
--- a/anomaly-benchmarking/generate-datasets/metadata.json
+++ b/anomaly-benchmarking/generate-datasets/metadata.json
@@ -14,25 +14,25 @@
       "name": "difficulty-map",
       "type": "map",
       "default": {"easy": 0.13333333, "medium": 0.33333333, "hard": 0.5, "very hard": 1},
-      "description": "How to categorize a row's point difficulty. This is a map of category levels (e.g. \"medium\") to the maximum allowed value for that level."
+      "description": "Categories for point difficulty"
     },
     {
       "name": "variance-map",
       "type": "map",
       "default":{"high scatter": 0.25, "medium scatter": 0.5, "low scatter": 1, "low clusteredness": 2, "medium clusteredness": 4, "high clusteredness": 1000000},
-      "description": "How to categorize a dataset's semantic variance. This is a map of category levels (e.g. \"low clusteredness\") to the maximum allowed ratio of variance of normal points to variance of anomalous points."
+      "description": "Categories for semantic variance"
     },
     {
       "name": "frequency-list",
       "type": "list",
       "default": [0.001, 0.005, 0.01, 0.05, 0.1],
-      "description": "Which relative frequencies will be generated."
+      "description": "Relative frequency levels"
     },
     {
       "name": "replicates",
       "type": "integer",
       "default": 10,
-      "description": "How many datasets to make at a given point difficulty, variance, and frequency."
+      "description": "How many datasets to make at given categories/levels"
     },
     {
       "name": "delete-resources",

--- a/anomaly-benchmarking/generate-datasets/metadata.json
+++ b/anomaly-benchmarking/generate-datasets/metadata.json
@@ -11,6 +11,30 @@
       "description": "The resource ids of the 'mother' datasets"
     },
     {
+      "name": "diff-map",
+      "type": "map",
+      "default": {"easy": 0.13333333, "medium": 0.33333333, "hard": 0.5, "very hard": 1},
+      "description": "How to categorize a row's point difficulty. This is a map of category levels (e.g. \"medium\") to the maximum allowed value for that level. The default is {\"easy\" 0.13333333 \"medium\" 0.33333333 \"hard\" 0.5 \"very hard\" 1}."
+    },
+    {
+      "name": "var-map",
+      "type": "map",
+      "default":{"high scatter": 0.25, "medium scatter": 0.5, "low scatter": 1, "low clusteredness": 2, "medium clusteredness": 4, "high clusteredness": 1000000},
+      "description": "How to categorize a dataset's semantic variance. This is a map of category levels (e.g. \"low clusteredness\") to the maximum allowed ratio of variance of normal points to variance of anomalous points. The default is {\"high scatter\" 0.25 \"medium scatter\" 0.5 \"low scatter\" 1 \"low clusteredness\" 2 \"medium clusteredness\" 4 \"high clusteredness\" 1000000}."
+    },
+    {
+      "name": "freq-list",
+      "type": "list",
+      "default": [0.001, 0.005, 0.01, 0.05, 0.1],
+      "description": "Which relative frequencies will be generated. The default for this list is [0.001 0.005 0.01 0.05 0.1]."
+    },
+    {
+      "name": "replicates",
+      "type": "integer",
+      "default": 10,
+      "description": "How many datasets to make at a given point difficulty, variance, and frequency. The default is ten."
+    },
+    {
       "name": "delete-resources",
       "type": "boolean",
       "default": true,

--- a/anomaly-benchmarking/generate-datasets/metadata.json
+++ b/anomaly-benchmarking/generate-datasets/metadata.json
@@ -11,28 +11,28 @@
       "description": "The resource ids of the 'mother' datasets"
     },
     {
-      "name": "diff-map",
+      "name": "difficulty-map",
       "type": "map",
       "default": {"easy": 0.13333333, "medium": 0.33333333, "hard": 0.5, "very hard": 1},
-      "description": "How to categorize a row's point difficulty. This is a map of category levels (e.g. \"medium\") to the maximum allowed value for that level. The default is {\"easy\" 0.13333333 \"medium\" 0.33333333 \"hard\" 0.5 \"very hard\" 1}."
+      "description": "How to categorize a row's point difficulty. This is a map of category levels (e.g. \"medium\") to the maximum allowed value for that level."
     },
     {
-      "name": "var-map",
+      "name": "variance-map",
       "type": "map",
       "default":{"high scatter": 0.25, "medium scatter": 0.5, "low scatter": 1, "low clusteredness": 2, "medium clusteredness": 4, "high clusteredness": 1000000},
-      "description": "How to categorize a dataset's semantic variance. This is a map of category levels (e.g. \"low clusteredness\") to the maximum allowed ratio of variance of normal points to variance of anomalous points. The default is {\"high scatter\" 0.25 \"medium scatter\" 0.5 \"low scatter\" 1 \"low clusteredness\" 2 \"medium clusteredness\" 4 \"high clusteredness\" 1000000}."
+      "description": "How to categorize a dataset's semantic variance. This is a map of category levels (e.g. \"low clusteredness\") to the maximum allowed ratio of variance of normal points to variance of anomalous points."
     },
     {
-      "name": "freq-list",
+      "name": "frequency-list",
       "type": "list",
       "default": [0.001, 0.005, 0.01, 0.05, 0.1],
-      "description": "Which relative frequencies will be generated. The default for this list is [0.001 0.005 0.01 0.05 0.1]."
+      "description": "Which relative frequencies will be generated."
     },
     {
       "name": "replicates",
       "type": "integer",
       "default": 10,
-      "description": "How many datasets to make at a given point difficulty, variance, and frequency. The default is ten."
+      "description": "How many datasets to make at a given point difficulty, variance, and frequency."
     },
     {
       "name": "delete-resources",

--- a/anomaly-benchmarking/generate-datasets/metadata.json
+++ b/anomaly-benchmarking/generate-datasets/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Generate benchmarking datasets",
-  "description": "Creates a suite of benchmark datasets for anomaly detection algorithms",
+  "description": "This script takes a list of datasets and transforms them into a suite of ground-truthed benchmarking datasets for anomaly detection. It depends on the library make-binary. These output datasets vary along the dimensions point difficulty, relative frequency of anomalies, and clusteredness. How these dimensions are discretized can be altered with the inputs difficulty-map, variance-map, and frequency-list. Please see the script [readme](https://github.com/whizzml/examples/blob/master/anomaly-benchmarking/generate-datasets/readme.md) for more details.",
   "kind": "script",
   "source_code": "script.whizzml",
   "imports": ["../make-binary"],
@@ -30,7 +30,7 @@
     },
     {
       "name": "replicates",
-      "type": "integer",
+      "type": "number",
       "default": 10,
       "description": "How many datasets to make at given categories/levels"
     },

--- a/anomaly-benchmarking/generate-datasets/script.whizzml
+++ b/anomaly-benchmarking/generate-datasets/script.whizzml
@@ -1,3 +1,12 @@
+;; Takes a map of bin labels and max edges, and returns a sorted list
+;; of maps
+
+(define (map-to-list my-map)
+  (let (my-keys (keys my-map)
+        my-list (map (lambda (x) (make-map ["level" "max"] [x (my-map x)]))
+                     my-keys))
+    (sort-by-key "max" my-list)))
+
 ;; Takes a dataset, returns the same dataset with all fields marked preferred
 
 (define (all-preferred ds-id)
@@ -21,27 +30,37 @@
 ;; returns a dataset of only anomalous points and a new field
 ;; labeling each row by one of four difficulty levels.
 
-(define (point-difficulty ds-id new-obj delete-resources)
+(define (point-difficulty ds-id new-obj delete-resources diff-list)
   (let (ds (all-preferred ds-id)
         lr-id (create-and-wait-logisticregression ds)
-        bp-id (wait (create-batchprediction lr-id ds {"probabilities" true 
-                                                      "output_dataset" true 
-                                                      "all_fields" true }))
+        bp-id (wait (create-batchprediction lr-id 
+                                            ds 
+                                            {"probabilities" true 
+                                             "output_dataset" true 
+                                             "all_fields" true 
+                                             "prediction_name" "bp"}))
         prob-ds-id ((fetch bp-id) "output_dataset_resource")
         prob-ds (fetch (wait prob-ds-id))
+        pred-field (get-id prob-ds "bp")
         norm-field (get-id prob-ds "normal probability")
         ano-field (get-id prob-ds "anomalous probability")
-        diff-sort (flatline "(segment-label {{norm-field}}" 
-                            "               \"easy\" 0.133333"
-                            "               \"medium\" 0.333333"
-                            "               \"hard\" 0.5"
-                            "               \"very hard\")")
+        other-bins (butlast diff-list)
+        last-bin ((last diff-list) "level")
+        my-bins (reduce (lambda (x y) 
+                          (str x "\"" (y "level") "\" " (y "max") " "))
+                        ""
+                        other-bins)
+        diff-sort (flatline "(segment-label {{norm-field}}"
+                            "               {my-bins}"
+                            "               {{last-bin}})") 
         my-filter (flatline "(= (field {{new-obj}}) \"anomalous\")")
         diff-ds (wait (create-dataset prob-ds-id 
                                       {"lisp_filter" my-filter
                                        "new_fields" [{"field" diff-sort
                                                       "name" "sorted"}]
-                                       "all_but" [norm-field ano-field]})))
+                                       "all_but" [norm-field 
+                                                  ano-field 
+                                                  pred-field]})))
     (when delete-resources
       (map safe-delete [lr-id bp-id prob-ds-id]))
     diff-ds))
@@ -50,14 +69,15 @@
 ;; into one of four new datasets based on their label. Returns the
 ;; list of these new datasets.
 
-(define (split-difficulty ds-id)
+(define (split-difficulty ds-id diff-list)
   (let (ds (fetch ds-id)
         split-field (get-id ds "sorted")
         split-list (ds ["fields" split-field "summary" "categories"]) 
         split-map (make-map (map head split-list)(map last split-list))
         split-it (lambda (level)
-                   (let (my-filter (flatline "(= (f {{split-field}})" 
-                                             "   {{level}})"))
+                   (let (my-filter (flatline "(= (f {{split-field}})"
+                                             " "
+                                             "      {{level}})"))
                      (if (contains? split-map level) 
                        (wait (create-dataset {"origin_dataset" ds-id
                                               "lisp_filter" my-filter
@@ -65,7 +85,7 @@
                                               "name" (str level " diff")
                                               "tags" [level]}))
                        false))))
-    (map split-it ["easy" "medium" "hard" "very hard"])))
+    (map split-it (map (lambda (x) (x "level")) diff-list))))
 
 ;; Takes a dataset and creates two datasets, one from the lowest
 ;; anomaly scores and one from the highest. Returns a list of the
@@ -105,7 +125,11 @@
 ;; found by abusing k-means; it creates just one cluster which contains
 ;; all the data.
 
-(define (variance-ratios ano-ds-id norm-var norm-scales delete-resources)
+(define (variance-ratios ano-ds-id 
+                         norm-var 
+                         norm-scales 
+                         delete-resources 
+                         var-list)
   (let (ano-ds (fetch ano-ds-id)
         my-tags (ano-ds "tags")
         ano-cl-id (create-and-wait-cluster {"dataset" ano-ds-id 
@@ -117,12 +141,10 @@
                                     "distance"
                                     "standard_deviation"])
         my-ratio (pow (/ norm-var ano-var) 2)
-        new-tag (cond (< my-ratio 0.25) "high scatter"
-                      (< my-ratio 0.5) "medium scatter"
-                      (< my-ratio 1) "low scatter"
-                      (< my-ratio 2) "low clusteredness"
-                      (< my-ratio 4) "medium clusteredness"
-                      "high clusteredness"))
+        new-tag (loop (x (head var-list) rest (tail var-list))
+                  (cond (empty? rest) (x "level")
+                        (< my-ratio (x "max")) (x "level")
+                        (recur (head rest) (tail rest)))))
     (when delete-resources
       (map safe-delete [ano-cl-id]))
     (update ano-ds-id {"tags" (append my-tags new-tag)})))
@@ -131,16 +153,16 @@
 ;; possible. Generates the max possible datasets (limit 40) at those
 ;; frequencies. Returns a list of datasets.
 
-(define (relative-frequency ds-id normal-rows)
+(define (relative-frequency ds-id normal-rows replicates freq-list)
   (let (ds (fetch ds-id)
         rows (ds "rows")
         ds-name (ds "name")
         my-tags (ds "tags")
         max-freq (/ rows (+ rows normal-rows)))
-    (for (freq [0.001 0.005 0.01 0.05 0.1])
+    (for (freq freq-list)
       (let (k (/ (* freq normal-rows) (- 1 freq)))
         (when (> max-freq freq)
-          (repeatedly (min 10 (floor (/ rows k))) 
+          (repeatedly (min replicates (floor (/ rows k))) 
                       (lambda () (create-dataset {"origin_dataset" ds-id
                                                   "sample_rate" (/ k rows)
                                                   "name" (str ds-name 
@@ -169,8 +191,15 @@
 ;; specifying the resource id, difficulty, semantic variation, and
 ;; frequency.
 
-(define (generate ds-id delete-resources)
-  (let (old-obj ((fetch ds-id) ["objective_field" "id"])
+(define (generate ds-id 
+                  diff-map 
+                  var-map 
+                  freq-list 
+                  replicates 
+                  delete-resources)
+  (let (diff-list (map-to-list diff-map)
+        var-list (map-to-list var-map)
+        old-obj ((fetch ds-id) ["objective_field" "id"])
         binary (make-binary ds-id old-obj delete-resources)
         new-obj ((fetch binary) ["objective_field" "id"])
         norm-filter (flatline "(= (field {{new-obj}}) \"normal\")")
@@ -185,8 +214,9 @@
                            "distance" 
                            "standard_deviation"])
         norm-scales (norm-cl "scales")
-        diff-ds (point-difficulty binary new-obj delete-resources)
-        difficulty-list (filter (lambda (x) x) (split-difficulty diff-ds))
+        diff-ds (point-difficulty binary new-obj delete-resources diff-list)
+        difficulty-list (filter (lambda (x) x) 
+                                (split-difficulty diff-ds diff-list))
         variation-list (flatten [] 
                                 (for (x difficulty-list)
                                   (when x 
@@ -196,13 +226,17 @@
         frequency-list (flatten []
                                 (for (x variation-list)
                                   (when x 
-                                    (relative-frequency x normal-rows))))
+                                    (relative-frequency x 
+                                                        normal-rows 
+                                                        replicates 
+                                                        freq-list))))
         labeled-by-variation (for (x frequency-list)
                                (when x 
                                  (variance-ratios x 
                                                   norm-var 
                                                   norm-scales 
-                                                  delete-resources))) 
+                                                  delete-resources
+                                                  var-list))) 
         final-list (for (x labeled-by-variation)
                      (if x (generate-map x normal-ds))))
     (when delete-resources
@@ -216,4 +250,9 @@
     (filter (lambda (x) x) final-list)))
 
 (define generated-datasets
-  (for (x dataset-list) (generate x delete-resources)))
+  (for (x dataset-list) (generate x 
+                                  diff-map 
+                                  var-map 
+                                  freq-list 
+                                  replicates 
+                                  delete-resources)))

--- a/anomaly-benchmarking/generate-datasets/script.whizzml
+++ b/anomaly-benchmarking/generate-datasets/script.whizzml
@@ -1,11 +1,12 @@
 ;; Takes a map of bin labels and max edges, and returns a sorted list
 ;; of maps
 
-(define (map-to-list my-map)
-  (let (my-keys (keys my-map)
-        my-list (map (lambda (x) (make-map ["level" "max"] [x (my-map x)]))
-                     my-keys))
-    (sort-by-key "max" my-list)))
+(define (map-to-list edges-map)
+  (let (labels (keys edges-map)
+        edges-list (map (lambda (x) (make-map ["level" "max"] 
+                                              [x (edges-map x)]))
+                     labels))
+    (sort-by-key "max" edges-list)))
 
 ;; Takes a dataset, returns the same dataset with all fields marked preferred
 
@@ -33,15 +34,17 @@
 (define (point-difficulty ds-id new-obj delete-resources diff-list)
   (let (ds (all-preferred ds-id)
         lr-id (create-and-wait-logisticregression ds)
+        pred-name (str "prediction for " 
+                       ((fetch ds) ["objective_field" "name"]))
         bp-id (wait (create-batchprediction lr-id 
                                             ds 
                                             {"probabilities" true 
                                              "output_dataset" true 
                                              "all_fields" true 
-                                             "prediction_name" "bp"}))
+                                             "prediction_name" pred-name}))
         prob-ds-id ((fetch bp-id) "output_dataset_resource")
         prob-ds (fetch (wait prob-ds-id))
-        pred-field (get-id prob-ds "bp")
+        pred-field (get-id prob-ds pred-name)
         norm-field (get-id prob-ds "normal probability")
         ano-field (get-id prob-ds "anomalous probability")
         other-bins (butlast diff-list)
@@ -150,8 +153,8 @@
     (update ano-ds-id {"tags" (append my-tags new-tag)})))
 
 ;; Takes a dataset. Determines which relative frequencies are
-;; possible. Generates the max possible datasets (limit 40) at those
-;; frequencies. Returns a list of datasets.
+;; possible. Generates the max possible datasets (limit 10 by default)
+;; at those frequencies. Returns a list of datasets.
 
 (define (relative-frequency ds-id normal-rows replicates freq-list)
   (let (ds (fetch ds-id)
@@ -161,7 +164,7 @@
         max-freq (/ rows (+ rows normal-rows)))
     (for (freq freq-list)
       (let (k (/ (* freq normal-rows) (- 1 freq)))
-        (when (> max-freq freq)
+        (when (and (> max-freq freq) (> k 10))
           (repeatedly (min replicates (floor (/ rows k))) 
                       (lambda () (create-dataset {"origin_dataset" ds-id
                                                   "sample_rate" (/ k rows)
@@ -251,8 +254,8 @@
 
 (define generated-datasets
   (for (x dataset-list) (generate x 
-                                  diff-map 
-                                  var-map 
-                                  freq-list 
+                                  difficulty-map 
+                                  variance-map 
+                                  frequency-list 
                                   replicates 
                                   delete-resources)))

--- a/anomaly-benchmarking/generate-datasets/script.whizzml
+++ b/anomaly-benchmarking/generate-datasets/script.whizzml
@@ -163,16 +163,19 @@
         my-tags (ds "tags")
         max-freq (/ rows (+ rows normal-rows)))
     (for (freq freq-list)
-      (let (k (/ (* freq normal-rows) (- 1 freq)))
-        (when (and (> max-freq freq) (> k 10))
-          (repeatedly (min replicates (floor (/ rows k))) 
-                      (lambda () (create-dataset {"origin_dataset" ds-id
-                                                  "sample_rate" (/ k rows)
-                                                  "name" (str ds-name 
-                                                              " - " 
-                                                              freq)
-                                                  "tags" (append my-tags 
-                                                                 (str freq))}))))))))
+      (try
+        (let (k (/ (* freq normal-rows) (- 1 freq)))
+          (when (and (> max-freq freq) (> k 10))
+            (repeatedly (min replicates (floor (/ rows k))) 
+                        (lambda () (create-dataset {"origin_dataset" ds-id
+                                                    "sample_rate" (/ k rows)
+                                                    "name" (str ds-name 
+                                                                " - " 
+                                                                freq)
+                                                    "tags" (append my-tags 
+                                                                   (str freq))})))))
+        (catch e
+          (log-error "Skipping frequency " freq ": " e))))))
   
 ;; Given an anomalous dataset and a normal dataset, combines them into
 ;; a single dataset, and returns a map with key/value pairs from the

--- a/anomaly-benchmarking/metadata.json
+++ b/anomaly-benchmarking/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Anomaly benchmarking",
-  "description": "Creates a suite of datasets for benchmarking anomaly detectors",
+  "description": "Creates a suite of benchmark datasets for anomaly detection algorithms",
   "kind": "package",
   "components": [
       "make-binary",

--- a/anomaly-benchmarking/test/test.sh
+++ b/anomaly-benchmarking/test/test.sh
@@ -39,7 +39,7 @@ fi
 
 # building the inputs for the second test
 prefix='[["dataset-list", ["'
-suffix='"]], ["diff-map", {"easy": 0.1333333}], ["freq-list", [0.001]]]'
+suffix='"]], ["difficulty-map", {"easy": 0.1333333}], ["frequency-list", [0.001]]]'
 text=''
 cat cmd/pre_test/dataset | while read dataset
 do

--- a/anomaly-benchmarking/test/test.sh
+++ b/anomaly-benchmarking/test/test.sh
@@ -13,15 +13,15 @@ run_bigmler whizzml --package-dir ../ --output-dir ./.build
 run_bigmler --train https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data --no-model \
             --project "Whizzml examples tests" --output-dir cmd/pre_test
 
-# building the inputs for the test
+# building the inputs for the first test
 prefix='[["dataset-list", ["'
-suffix='"]]]'
+suffix='"]], ["replicates", 1]]'
 text=''
 cat cmd/pre_test/dataset | while read dataset
 do
 echo "$prefix$dataset$suffix" > "test_inputs.json"
 done
-log "Testing generate-datasets script -------------------------------"
+log "Testing generate-datasets script (one replicate)  -------------"
 # running the execution with the given inputs
 run_bigmler execute --scripts .build/generate-datasets/scripts --inputs test_inputs.json \
                     --output-dir cmd/results
@@ -31,9 +31,33 @@ declare regex="\"outputs\": \[\[\"generated-datasets\", "
 declare file_content=$( cat "${file}" )
 if [[ " $file_content " =~ $regex ]]
     then
-        log "generate-datasets OK"
+        log "one replicate OK"
     else
-        echo "generate-datasets KO:\n $file_content"
+        echo "one replicate KO:\n $file_content"
+        exit 1
+fi
+
+# building the inputs for the second test
+prefix='[["dataset-list", ["'
+suffix='"]], ["diff-map", {"easy": 0.1333333}], ["freq-list", [0.001]]]'
+text=''
+cat cmd/pre_test/dataset | while read dataset
+do
+echo "$prefix$dataset$suffix" > "test_inputs.json"
+done
+log "Testing generate-datasets script (ten replicates)  -------------"
+# running the execution with the given inputs
+run_bigmler execute --scripts .build/generate-datasets/scripts --inputs test_inputs.json \
+                    --output-dir cmd/results
+# check the outputs
+declare file="cmd/results/whizzml_results.json"
+declare regex="\"outputs\": \[\[\"generated-datasets\", "
+declare file_content=$( cat "${file}" )
+if [[ " $file_content " =~ $regex ]]
+    then
+        log "ten replicates OK"
+    else
+        echo "ten replicates KO:\n $file_content"
         exit 1
 fi
 # remove the created resources


### PR DESCRIPTION
The new test is broken into two parts, and takes about 25 minutes to run. This meant adding some user-defined inputs. The default is the same as before, but now the categories for point difficulty and semantic variance and the relative frequency levels can all be changed by the user.