### PR TITLE
Bug fix: using the training split in best-first algorithm

### DIFF
--- a/best-first/metadata.json
+++ b/best-first/metadata.json
@@ -16,6 +16,12 @@
       "description": "The number of features to select"
     },
     {
+      "name": "split-fraction",
+      "type": "number",
+      "default": 0.5,
+      "descript": "Train/test split ratio used for training/evaluation of models"
+    },
+    {
       "name": "objective-id",
       "type": "string",
       "default": "",

--- a/best-first/script.whizzml
+++ b/best-first/script.whizzml
@@ -13,11 +13,6 @@
                             "out_of_bag" oob
                             "seed" "whizzml-example"}))
 
-;; Split a dataset into training and test sets
-(define (split-dataset ds-id rate)
-  (list (sample-dataset ds-id rate false)
-        (sample-dataset ds-id rate true)))
-
 ;; Get the default set of input fields for this dataset (all preferred
 ;; fields minus the objective field).
 (define (default-inputs dataset-id obj-id)
@@ -68,22 +63,21 @@
 ;; evaluate them, and add the feature corresponding to the best
 ;; evaluation to the running set of features.  Stop when you reach the
 ;; target number, or you run out of features.
-(define (select-features dataset-id nfeatures objective-id)
+(define (select-features dataset-id nfeatures rate objective-id)
   (let (obj-id (get-objective dataset-id objective-id)
         input-ids (default-inputs dataset-id obj-id)
-        splits (split-dataset dataset-id 0.5)
-        train-id (nth splits 0)
-        test-id (nth splits 1))
+        [train-id test-id] (create-random-dataset-split dataset-id rate))
     (loop (selected []
            potentials input-ids)
       (if (or (>= (count selected) nfeatures) (empty? potentials))
         (feature-names dataset-id selected)
         (let (_ (log-info "Making models...")
-              model-ids (make-models dataset-id obj-id selected potentials)
+              model-ids (make-models train-id obj-id selected potentials)
               _ (log-info "Selecting feature...")
               next-feat (select-feature test-id potentials model-ids)
               _ (log-info "Selected feature is " next-feat))
           (recur (cons next-feat selected)
                  (filter (lambda (id) (not (= id next-feat))) potentials)))))))
 
-(define output-features (select-features dataset-id n objective-id))
+(define output-features
+  (select-features dataset-id n split-fraction objective-id))

--- a/best-first/script.whizzml
+++ b/best-first/script.whizzml
@@ -6,13 +6,6 @@
   (let (fields ((fetch dataset-id) "fields"))
     (map (lambda (id) (fields [id "name"])) ids)))
 
-;; Create a dataset sample
-(define (sample-dataset ds-id rate oob)
-  (create-and-wait-dataset {"sample_rate" rate
-                            "origin_dataset"  ds-id
-                            "out_of_bag" oob
-                            "seed" "whizzml-example"}))
-
 ;; Get the default set of input fields for this dataset (all preferred
 ;; fields minus the objective field).
 (define (default-inputs dataset-id obj-id)


### PR DESCRIPTION
We were using the full original dataset to train models.  Also using
the standard library to create random splits, instead of our own.

/cc @talvarez