### PR TITLE
Ordinal encoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 */test/test_inputs.json
 *~
 /model-per-category/test/.bigmler
+/ordinal-encoder/test/.python-version

--- a/metadata.json
+++ b/metadata.json
@@ -18,6 +18,7 @@
     "model-or-ensemble",
     "model-per-category",
     "model-per-cluster",
+    "ordinal-encoder",
     "remove-anomalies",
     "unify-optype",
     "seeded-best-k",

--- a/ordinal-encoder/metadata.json
+++ b/ordinal-encoder/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "Ordinal encoder.",
-    "description": "Given a dataset, encodes categorical fields using ordinal ecoding, which uses a single column of integers to represent field classes (levels).",
+    "description": "Given a dataset, encodes categorical fields using ordinal encoding, which uses a single column of integers to represent field classes (levels). It then creates a new dataset, with additional fields containing ordinal encodings of the categorical fields.\n\nIf classes have a known order (such as Like, Somewhat Like, Neutral, Somewhat Dislike, and Dislike), the integer mapping can be supplied; otherwise, integers are assigned to classes arbitrarily.\n\nFor more information, please see the [readme](https://github.com/whizzml/examples/tree/master/ordinal-encoder).",
     "kind": "script",
     "source_code": "script.whizzml",
     "inputs": [

--- a/ordinal-encoder/metadata.json
+++ b/ordinal-encoder/metadata.json
@@ -1,6 +1,6 @@
 {
-    "name": "Encodes categorical features using ordinal ecoding.",
-    "description": "Given a dataset, encodes categorical features using ordinal ecoding. Ordinal encoding uses a single column of integers to represent the feature classes (levels).",
+    "name": "Ordinal encoder.",
+    "description": "Given a dataset, encodes categorical fields using ordinal ecoding, which uses a single column of integers to represent field classes (levels).",
     "kind": "script",
     "source_code": "script.whizzml",
     "inputs": [
@@ -13,13 +13,13 @@
             "name": "target-fields",
             "type": "list",
             "default": [],
-            "description": "[Optional] A list of field names or identifiers to encode. If not supplied, or an empty list, all categorical columns are encoded."
+            "description": "[Optional] A list of field names or identifiers to encode. Non-categorical fields are ignored. If not supplied, or an empty list, all categorical columns are encoded."
         },
         {
-            "name": "orderings",
+            "name": "mappings",
             "type": "map",
             "default": {},
-            "description": "[Optional]"
+            "description": "[Optional] A map for the encoding of each field. Top-level keys are field names or identifiers. Values are maps of classes to integers. For example, {'col1': {'A': 0, 'B': 1, 'C': 2}}. If no mapping is given for a field, classes are assumed to have no true order and integers are assigned at random. An incomplete mapping for a field results in missing values in the new (ordinal) field."
         }
     ],
     "outputs": [

--- a/ordinal-encoder/metadata.json
+++ b/ordinal-encoder/metadata.json
@@ -19,7 +19,7 @@
             "name": "mappings",
             "type": "map",
             "default": {},
-            "description": "[Optional] A map for the encoding of each field. Top-level keys are field names or identifiers. Values are maps of classes to integers. For example, {'col1': {'A': 0, 'B': 1, 'C': 2}}. If no mapping is given for a field, classes are assumed to have no true order and integers are assigned at random. An incomplete mapping for a field results in missing values in the new (ordinal) field."
+            "description": "[Optional] A map for the encoding of each field. Top-level keys are field names or identifiers. Values are maps of classes to integers. For example, {'col1': {'A': 0, 'B': 1, 'C': 2}}. If no mapping is given for a field, classes are assumed to have no true order and integers are assigned at random. An incomplete mapping for a field causes missing values in the new (ordinal) field."
         }
     ],
     "outputs": [

--- a/ordinal-encoder/metadata.json
+++ b/ordinal-encoder/metadata.json
@@ -1,0 +1,32 @@
+{
+    "name": "Encodes categorical features using ordinal ecoding.",
+    "description": "Given a dataset, encodes categorical features using ordinal ecoding. Ordinal encoding uses a single column of integers to represent the feature classes (levels).",
+    "kind": "script",
+    "source_code": "script.whizzml",
+    "inputs": [
+        {
+            "name": "input-dataset-id",
+            "type": "dataset-id",
+            "description": "Dataset to be encoded."
+        },
+        {
+            "name": "target-fields",
+            "type": "list",
+            "default": [],
+            "description": "[Optional] A list of field names or identifiers to encode. If not supplied, or an empty list, all categorical columns are encoded."
+        },
+        {
+            "name": "orderings",
+            "type": "map",
+            "default": {},
+            "description": "[Optional]"
+        }
+    ],
+    "outputs": [
+        {
+            "name": "output-dataset-id",
+            "type": "dataset-id",
+            "description": "New dataset with categorical fields encoded."
+        }
+    ]
+}

--- a/ordinal-encoder/metadata.json
+++ b/ordinal-encoder/metadata.json
@@ -19,7 +19,7 @@
             "name": "mappings",
             "type": "map",
             "default": {},
-            "description": "[Optional] A map for the encoding of each field. Top-level keys are field names or identifiers. Values are maps of classes to integers. For example, {'col1': {'A': 0, 'B': 1, 'C': 2}}. If no mapping is given for a field, classes are assumed to have no true order and integers are assigned at random. An incomplete mapping for a field causes missing values in the new (ordinal) field."
+            "description": "[Optional] A map for the encoding of each field. Top-level keys are field names or identifiers. Values are maps of classes to integers. For example, {'col1': {'A': 0, 'B': 1, 'C': 2}}. If no mapping is given for a field, integers are assigned to classes arbitrarily. An incomplete mapping for a field causes missing values in the new (ordinal) field."
         }
     ],
     "outputs": [

--- a/ordinal-encoder/metadata.json
+++ b/ordinal-encoder/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "Ordinal encoder.",
-    "description": "Given a dataset, encodes categorical fields using ordinal encoding, which uses a single column of integers to represent field classes (levels). It then creates a new dataset, with additional fields containing ordinal encodings of the categorical fields.\n\nIf classes have a known order (such as Like, Somewhat Like, Neutral, Somewhat Dislike, and Dislike), the integer mapping can be supplied; otherwise, integers are assigned to classes arbitrarily.\n\nFor more information, please see the [readme](https://github.com/whizzml/examples/tree/master/ordinal-encoder).",
+    "description": "Given a dataset, encodes categorical fields using ordinal encoding, which uses a single column of integers to represent field classes (levels). It then creates a new dataset, with additional fields containing ordinal encodings of the categorical fields.\n\nIf classes have a known order (such as Like, Somewhat Like, Neutral, Somewhat Dislike, and Dislike), the integer mapping can be supplied; otherwise, integers are assigned by class count, in descending order (in the case of ties, classes are ordered alphabetically).\n\nFor more information, please see the [readme](https://github.com/whizzml/examples/tree/master/ordinal-encoder).",
     "kind": "script",
     "source_code": "script.whizzml",
     "inputs": [
@@ -19,7 +19,7 @@
             "name": "mappings",
             "type": "map",
             "default": {},
-            "description": "[Optional] A map for the encoding of each field. Top-level keys are field names or identifiers. Values are maps of classes to integers. For example, {'col1': {'A': 0, 'B': 1, 'C': 2}}. If no mapping is given for a field, integers are assigned to classes arbitrarily. An incomplete mapping for a field causes missing values in the new (ordinal) field."
+            "description": "[Optional] A map for the encoding of each field. Top-level keys are field names or identifiers. Values are maps of classes to integers. For example, {'col1': {'A': 0, 'B': 1, 'C': 2}}. If no mapping is given for a field, integers are assigned by class count, in descending order (in the case of ties, classes are ordered alphabetically). An incomplete mapping for a field causes missing values in the new (ordinal) field."
         }
     ],
     "outputs": [

--- a/ordinal-encoder/readme.md
+++ b/ordinal-encoder/readme.md
@@ -2,5 +2,5 @@
 
 This script takes as inputs a dataset, and optionally a list of categorical fields and mappings from field classes to integers. It then creates a new dataset, with additional fields containing ordinal encodings of the categorical fields.
 
-Ordinal encoding uses a single column of integers to represent field classes. If classes have a known order (such as Like, Somewhat Like, Neutral, Somewhat Dislike, and Dislike), the integer mapping can be supplied; otherwise, integers are assigned to classes arbitrarily.
+Ordinal encoding uses a single column of integers to represent field classes. If classes have a known order (such as Like, Somewhat Like, Neutral, Somewhat Dislike, and Dislike), the integer mapping can be supplied; otherwise, integers are assigned by class count, in descending order (in the case of ties, classes are ordered alphabetically).
 

--- a/ordinal-encoder/readme.md
+++ b/ordinal-encoder/readme.md
@@ -1,6 +1,6 @@
 # Encode categorical fields using ordinal encoding
 
-This script takes as inputs a dataset, and optionally a list of categorical fields and mappings from field classes to integers.  It then creates a new dataset, with additional fields containing ordinal encodings of the categorical fields.
+This script takes as inputs a dataset, and optionally a list of categorical fields and mappings from field classes to integers. It then creates a new dataset, with additional fields containing ordinal encodings of the categorical fields.
 
-Ordinal encoding uses a single column of integers to represent field classes. If classes have a known order (such as Like, Like Somewhat, Neutral, Dislike, and Somewhat Dislike), the integer mapping can be supplied; otherwise, integers are assigned at random.
+Ordinal encoding uses a single column of integers to represent field classes. If classes have a known order (such as Like, Somewhat Like, Neutral, Somewhat Dislike, and Dislike), the integer mapping can be supplied; otherwise, integers are assigned to classes arbitrarily.
 

--- a/ordinal-encoder/readme.md
+++ b/ordinal-encoder/readme.md
@@ -1,0 +1,12 @@
+# Filter a dataset on row population percentange
+
+Script to remove rows from a dataset that are less than `n` percent populated.
+Returns a new dataset with the specified filter applied.
+
+Given an input dataset:
+
+- Retrieves information about each field.
+- Determines whether or not each field is greater than `n` percent populated.
+- Creates a list of field names that do not meet the criteria.
+- Creates and returns a new dataset, excluding the fields that did not
+  meet the criteria.

--- a/ordinal-encoder/readme.md
+++ b/ordinal-encoder/readme.md
@@ -1,12 +1,6 @@
-# Filter a dataset on row population percentange
+# Encode categorical fields using ordinal encoding
 
-Script to remove rows from a dataset that are less than `n` percent populated.
-Returns a new dataset with the specified filter applied.
+This script takes as inputs a dataset, and optionally a list of categorical fields and mappings from field classes to integers.  It then creates a new dataset, with additional fields containing ordinal encodings of the categorical fields.
 
-Given an input dataset:
+Ordinal encoding uses a single column of integers to represent field classes. If classes have a known order (such as Like, Like Somewhat, Neutral, Dislike, and Somewhat Dislike), the integer mapping can be supplied; otherwise, integers are assigned at random.
 
-- Retrieves information about each field.
-- Determines whether or not each field is greater than `n` percent populated.
-- Creates a list of field names that do not meet the criteria.
-- Creates and returns a new dataset, excluding the fields that did not
-  meet the criteria.

--- a/ordinal-encoder/script.whizzml
+++ b/ordinal-encoder/script.whizzml
@@ -23,10 +23,9 @@
 (define (ordinal-encode dataset-id target-fields mappings)
   (let (ds (fetch dataset-id)
         fields (resource-fields ds)
-        fields
-          (reduce (lambda (m k) (assoc-in m [k "id"] k))
-                   fields
-                   (keys fields))
+        fields (reduce (lambda (m k) (assoc-in m [k "id"] k))
+                       fields
+                       (keys fields))
         fields
           (if (= 0 (count target-fields))
               (values fields)
@@ -34,10 +33,9 @@
                       (map (lambda (x) (find-field fields x)) target-fields)))
         fields (filter categorical-field? fields)
         new-fields (map (lambda (x) (get-new-field x mappings)) fields)
-        args
-        {"origin_dataset" dataset-id
-         "name" (str (ds "name") " - ordinal encoded")
-         "new_fields" new-fields})
+        args {"origin_dataset" dataset-id
+              "name" (str (ds "name") " - ordinal encoded")
+              "new_fields" new-fields})
     (if (= 0 (count fields)) "" (create "dataset" args))))
 
 ;; Inputs and outputs

--- a/ordinal-encoder/script.whizzml
+++ b/ordinal-encoder/script.whizzml
@@ -1,12 +1,4 @@
-;; foo
-;;
-;; Creates a new dataset from the one given as argument...
-;;
-;; Inputs:
-;;   dataset-id: (dataset-id) ID of the origin dataset
-;;
-;; Output: (dataset-id) ID of the new dataset
-
+;; Ordinal encoder for categorical fields.
 
 
 ;; Get a flatline generator for encoding the specified field using the given
@@ -27,6 +19,7 @@
     {"name" (str (field "name") "_ordinal")
      "field" (get-field-flatline (field "name") mapping)}))
 
+;; Main workflow function
 (define (ordinal-encode dataset-id target-fields mappings)
   (let (ds (fetch dataset-id)
         fields (resource-fields ds)
@@ -47,6 +40,7 @@
          "new_fields" new-fields})
     (if (= 0 (count fields)) "" (create "dataset" args))))
 
+;; Inputs and outputs
 (define output-dataset-id
   (ordinal-encode input-dataset-id target-fields mappings))
 

--- a/ordinal-encoder/script.whizzml
+++ b/ordinal-encoder/script.whizzml
@@ -1,0 +1,38 @@
+;; foo
+;;
+;; Creates a new dataset from the one given as argument...
+;;
+;; Inputs:
+;;   dataset-id: (dataset-id) ID of the origin dataset
+;;
+;; Output: (dataset-id) ID of the new dataset
+
+
+;; "new_fields" [{"name" "foo" "field" "bar"}]
+
+
+;; Get a flatline generator for encoding the specified field using the given
+;; mapping.
+(define (field-flatline field mapping)
+  (let (f (lambda (k) (str "(= x \"" k "\") " (mapping k)))
+        conds (join " " (map f (keys mapping))))
+    (flatline "(let (x (f {{field}})) (cond {conds}))")))
+
+(define (new-field field)
+  (let (classes (field-categories field)
+        mapping (make-map classes (range (count classes))))
+        {"name" (str (field "name") "_ordinal")
+         "field" (field-flatline (field "name") mapping)}))
+
+(define (ordinal-encode dataset-id)
+  (let (ds (fetch dataset-id)
+        fields (values (resource-fields ds))
+        new-fields (map new-field (filter categorical-field? fields))
+        args {"origin_dataset" dataset-id
+              "name" (str (ds "name") " - ordinal encoded")
+              "new_fields" new-fields})
+    (create "dataset" args)))
+
+
+(define output-dataset-id (ordinal-encode input-dataset-id))
+

--- a/ordinal-encoder/script.whizzml
+++ b/ordinal-encoder/script.whizzml
@@ -8,31 +8,45 @@
 ;; Output: (dataset-id) ID of the new dataset
 
 
-;; "new_fields" [{"name" "foo" "field" "bar"}]
-
 
 ;; Get a flatline generator for encoding the specified field using the given
 ;; mapping.
-(define (field-flatline field mapping)
+(define (get-field-flatline field mapping)
   (let (f (lambda (k) (str "(= x \"" k "\") " (mapping k)))
         conds (join " " (map f (keys mapping))))
     (flatline "(let (x (f {{field}})) (cond {conds}))")))
 
-(define (new-field field)
-  (let (classes (field-categories field)
-        mapping (make-map classes (range (count classes))))
-        {"name" (str (field "name") "_ordinal")
-         "field" (field-flatline (field "name") mapping)}))
+;; Get an argument map to encode the specified field as a new field.
+(define (get-new-field field mappings)
+  (let (mapping
+         (cond
+           (contains? mappings (field "name")) (mappings (field "name"))
+           (contains? mappings (field "id")) (mappings (field "id"))
+           (let (classes (field-categories field))
+             (make-map classes (range (count classes))))))
+    {"name" (str (field "name") "_ordinal")
+     "field" (get-field-flatline (field "name") mapping)}))
 
-(define (ordinal-encode dataset-id)
+(define (ordinal-encode dataset-id target-fields mappings)
   (let (ds (fetch dataset-id)
-        fields (values (resource-fields ds))
-        new-fields (map new-field (filter categorical-field? fields))
-        args {"origin_dataset" dataset-id
-              "name" (str (ds "name") " - ordinal encoded")
-              "new_fields" new-fields})
-    (create "dataset" args)))
+        fields (resource-fields ds)
+        fields
+          (reduce (lambda (m k) (assoc-in m [k "id"] k))
+                   fields
+                   (keys fields))
+        fields
+          (if (= 0 (count target-fields))
+              (values fields)
+              (filter (lambda (x) x)
+                      (map (lambda (x) (find-field fields x)) target-fields)))
+        fields (filter categorical-field? fields)
+        new-fields (map (lambda (x) (get-new-field x mappings)) fields)
+        args
+        {"origin_dataset" dataset-id
+         "name" (str (ds "name") " - ordinal encoded")
+         "new_fields" new-fields})
+    (if (= 0 (count fields)) "" (create "dataset" args))))
 
-
-(define output-dataset-id (ordinal-encode input-dataset-id))
+(define output-dataset-id
+  (ordinal-encode input-dataset-id target-fields mappings))
 

--- a/ordinal-encoder/test/test.sh
+++ b/ordinal-encoder/test/test.sh
@@ -2,22 +2,263 @@
 
 source ../../test-utils.sh
 
-rm -f -R cmd_del
-rm -f -R cmd
-rm -f -R .build
+outdir=cmd
+outdir_del=cmd_del
+
+function cleanup {
+  [ -d $outdir ] && \
+      run_bigmler delete --from-dir $outdir --output-dir $outdir_del
+  [ -d .build ] && \
+      run_bigmler delete --from-dir .build --output-dir $outdir_del
+  rm -f -R data.csv test_inputs.json
+  rm -f -R $outdir $outdir_del .build .bigmler* storage
+}
+
+function run_test {
+  data=$1
+  inputs=$2
+  expected=$3
+
+  log "Removing stale resources (if any)"
+  cleanup
+
+  run_bigmler whizzml --package-dir ../ --output-dir ./.build
+
+  log "Creating input dataset..."
+  echo "$data" > data.csv
+  run_bigmler --train "data.csv" --no-model --output-dir $outdir/ds
+  [ $? != 0 ] && echo "KO: Failed to create dataset" && exit 1
+  dataset_id=$(<$outdir/ds/dataset)
+  log "Dataset $dataset_id created"
+
+  log "Executing script..."
+  echo "${inputs/\%DATASET_ID\%/$dataset_id}" > test_inputs.json
+  run_bigmler execute --scripts .build/scripts  --inputs test_inputs.json \
+      --output-dir $outdir/results
+
+  log "Downloading output dataset..."
+  output_dataset_id=$(cat $outdir/results/whizzml_results.txt | grep "\'result\'" | cut -f4 -d\')
+  run_bigmler --dataset "$output_dataset_id" --to-csv "output_dataset.csv" --no-model --output-dir $outdir/results
+  actual=$(cat $outdir/results/output_dataset.csv)
+
+  log "Comparing actual result to expected..."
+  if [ "$actual" = "$expected" ]; then
+    log "PASS"
+  else
+    log "FAIL"
+    echo "Expected"
+    echo "$expected"
+    echo "Actual"
+    echo "$actual"
+    exit 1
+  fi
+  cleanup
+}
+
 
 log "-------------------------------------------------------"
-log "Test for low-coverage script"
-run_bigmler whizzml --package-dir ../ --output-dir ./.build
+log "Tests for ordinal-encoder script"
+
+data=$(cat <<'EOF'
+id,size,code
+0,XL,C
+1,S,A
+2,M,C
+3,M,B
+4,S,B
+5,L,C
+6,XL,C
+7,M,A
+EOF
+)
+
+log "Test: Default inputs"
+inputs=$(cat <<EOF
+[["input-dataset-id", "%DATASET_ID%"]]
+EOF
+)
+expected=$(cat <<'EOF'
+id,size,code,size_ordinal,code_ordinal
+0,XL,C,2,0
+1,S,A,1,1
+2,M,C,0,0
+3,M,B,0,2
+4,S,B,1,2
+5,L,C,3,0
+6,XL,C,2,0
+7,M,A,0,1
+EOF
+)
+run_test "$data" "$inputs" "$expected"
 
 
-# building the inputs for the first test
-inputs='[["input-dataset-id", "dataset/5b7e97ed00a1e52309000faf"]]'
-echo "$inputs" > "test_inputs.json"
+log "Test: Target fields"
+inputs=$(cat <<EOF
+[["input-dataset-id", "%DATASET_ID%"],
+ ["target-fields", ["size"]]]
+EOF
+)
+expected=$(cat <<'EOF'
+id,size,code,size_ordinal
+0,XL,C,2
+1,S,A,1
+2,M,C,0
+3,M,B,0
+4,S,B,1
+5,L,C,3
+6,XL,C,2
+7,M,A,0
+EOF
+)
+run_test "$data" "$inputs" "$expected"
 
-log "Testing low-coverage script  -------------"
-# running the execution with the given inputs
-run_bigmler execute --scripts .build/scripts  --inputs test_inputs.json \
-                    --output-dir cmd/results
+
+log "Test: Target fields by id"
+inputs=$(cat <<EOF
+[["input-dataset-id", "%DATASET_ID%"],
+ ["target-fields", ["size", "000002"]]]
+EOF
+)
+expected=$(cat <<'EOF'
+id,size,code,size_ordinal,code_ordinal
+0,XL,C,2,0
+1,S,A,1,1
+2,M,C,0,0
+3,M,B,0,2
+4,S,B,1,2
+5,L,C,3,0
+6,XL,C,2,0
+7,M,A,0,1
+EOF
+)
+run_test "$data" "$inputs" "$expected"
+
+
+log "Test: Mappings"
+inputs=$(cat <<EOF
+[["input-dataset-id", "%DATASET_ID%"],
+ ["target-fields", ["size"]],
+ ["mappings", {"size": {"S": 0,
+                        "M": 1,
+                        "L": 2,
+                        "XL": 3}}]]
+EOF
+)
+expected=$(cat <<'EOF'
+id,size,code,size_ordinal
+0,XL,C,3
+1,S,A,0
+2,M,C,1
+3,M,B,1
+4,S,B,0
+5,L,C,2
+6,XL,C,3
+7,M,A,1
+EOF
+)
+run_test "$data" "$inputs" "$expected"
+
+
+log "Test: Missing value in mapping"
+inputs=$(cat <<EOF
+[["input-dataset-id", "%DATASET_ID%"],
+ ["target-fields", ["size"]],
+ ["mappings", {"size": {"S": 0,
+                        "L": 2,
+                        "XL": 3}}]]
+EOF
+)
+expected=$(cat <<'EOF'
+id,size,code,size_ordinal
+0,XL,C,3
+1,S,A,0
+2,M,C,
+3,M,B,
+4,S,B,0
+5,L,C,2
+6,XL,C,3
+7,M,A,
+EOF
+)
+run_test "$data" "$inputs" "$expected"
+
+
+log "Test: Non-categorical target field"
+inputs=$(cat <<EOF
+[["input-dataset-id", "%DATASET_ID%"],
+ ["target-fields", ["id", "size"]]]
+EOF
+)
+expected=$(cat <<'EOF'
+id,size,code,size_ordinal
+0,XL,C,2
+1,S,A,1
+2,M,C,0
+3,M,B,0
+4,S,B,1
+5,L,C,3
+6,XL,C,2
+7,M,A,0
+EOF
+)
+run_test "$data" "$inputs" "$expected"
+
+log "Test: No categorical fields"
+inputs=$(cat <<EOF
+[["input-dataset-id", "%DATASET_ID%"],
+ ["target-fields", ["id"]]]
+EOF
+)
+expected=
+run_test "$data" "$inputs" "$expected"
+
+
+log "Test: Unknown target field"
+inputs=$(cat <<EOF
+[["input-dataset-id", "%DATASET_ID%"],
+ ["target-fields", ["foo", "size"]]]
+EOF
+)
+expected=$(cat <<'EOF'
+id,size,code,size_ordinal
+0,XL,C,2
+1,S,A,1
+2,M,C,0
+3,M,B,0
+4,S,B,1
+5,L,C,3
+6,XL,C,2
+7,M,A,0
+EOF
+)
+run_test "$data" "$inputs" "$expected"
+
+
+log "Test: Mapping by field id"
+inputs=$(cat <<EOF
+[["input-dataset-id", "%DATASET_ID%"],
+ ["mappings", {"000002": {"A": 0,
+                          "B": 1,
+                          "C": 2},
+               "size": {"S": 0,
+                        "M": 1,
+                        "L": 2,
+                        "XL": 3}}]]
+EOF
+)
+expected=$(cat <<'EOF'
+id,size,code,size_ordinal,code_ordinal
+0,XL,C,3,2
+1,S,A,0,0
+2,M,C,1,2
+3,M,B,1,1
+4,S,B,0,1
+5,L,C,2,2
+6,XL,C,3,2
+7,M,A,1,0
+EOF
+)
+run_test "$data" "$inputs" "$expected"
+
 
 

--- a/ordinal-encoder/test/test.sh
+++ b/ordinal-encoder/test/test.sh
@@ -19,7 +19,7 @@ function run_test {
   inputs=$2
   expected=$3
 
-  log "Removing stale resources (if any)"
+  log "Removing stale resources (if any)..."
   cleanup
 
   run_bigmler whizzml --package-dir ../ --output-dir ./.build
@@ -29,19 +29,19 @@ function run_test {
   run_bigmler --train "data.csv" --no-model --output-dir $outdir/ds
   [ $? != 0 ] && echo "KO: Failed to create dataset" && exit 1
   dataset_id=$(<$outdir/ds/dataset)
-  log "Dataset $dataset_id created"
+  log "Dataset $dataset_id created."
 
   log "Executing script..."
   echo "${inputs/\%DATASET_ID\%/$dataset_id}" > test_inputs.json
   run_bigmler execute --scripts .build/scripts  --inputs test_inputs.json \
       --output-dir $outdir/results
-
-  log "Downloading output dataset..."
   output_dataset_id=$(cat $outdir/results/whizzml_results.txt | grep "\'result\'" | cut -f4 -d\')
+
+  log "Downloading output dataset $output_dataset_id..."
   run_bigmler --dataset "$output_dataset_id" --to-csv "output_dataset.csv" --no-model --output-dir $outdir/results
   actual=$(cat $outdir/results/output_dataset.csv)
 
-  log "Comparing actual result to expected..."
+  log "Comparing actual to expected result..."
   if [ "$actual" = "$expected" ]; then
     log "PASS"
   else

--- a/ordinal-encoder/test/test.sh
+++ b/ordinal-encoder/test/test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+source ../../test-utils.sh
+
+rm -f -R cmd_del
+rm -f -R cmd
+rm -f -R .build
+
+log "-------------------------------------------------------"
+log "Test for low-coverage script"
+run_bigmler whizzml --package-dir ../ --output-dir ./.build
+
+
+# building the inputs for the first test
+inputs='[["input-dataset-id", "dataset/5b7e97ed00a1e52309000faf"]]'
+echo "$inputs" > "test_inputs.json"
+
+log "Testing low-coverage script  -------------"
+# running the execution with the given inputs
+run_bigmler execute --scripts .build/scripts  --inputs test_inputs.json \
+                    --output-dir cmd/results
+
+

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,9 @@ By convention, when the artifact is a library, the files are called
   extended with new fields containing the scaled values.
 - `stepwise-regression` Finds the best features for building a
   logistic regression using a greedy algorithm.
+- `ordinal-encoder` Given a dataset, encodes categorical fields using ordinal
+  ecoding, which uses a single column of integers to represent field classes
+  (levels).
 
 ## How to install
 


### PR DESCRIPTION
Request from Francisco. A simple script for ordinal encoding of categorical fields. If classes have a natural order, that can be supplied by the user; otherwise, the assignment of integers to classes is arbitrary.