### PR TITLE
adds multi-label prediction scripts and best-first with cross-validation

### DIFF
--- a/best-first-cv/metadata.json
+++ b/best-first-cv/metadata.json
@@ -1,0 +1,38 @@
+{
+  "name": "Best-first feature selection with cross-validation",
+  "description": "Find the best features for modeling using a greedy algorithm. Extends the best-first feature selection that only worked with models and used split-evaluation",
+  "kind": "script",
+  "source_code": "script.whizzml",
+  "inputs": [
+    {
+      "name": "dataset-id",
+      "type": "dataset-id",
+      "description": "The data to select features from"
+    },
+    {
+      "name": "n",
+      "type": "number",
+      "default": 3,
+      "description": "The number of features to select"
+    },
+    {
+      "name": "objective-id",
+      "type": "string",
+      "default": "",
+      "description": "Objective field ID, or empty for default dataset objective field"
+    },
+    {
+      "name": "options",
+      "type": "map",
+      "default": {},
+      "descript": "Additional configuration options for the models"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "output-features",
+      "type": "list",
+      "description": "The list of the n selected fields"
+    }
+  ]
+}

--- a/best-first-cv/metadata.json
+++ b/best-first-cv/metadata.json
@@ -26,6 +26,12 @@
       "type": "map",
       "default": {},
       "descript": "Additional configuration options for the models"
+    },
+    {
+      "name": "k-folds",
+      "type": "number",
+      "default": 5,
+      "descript": "Number of k-folds in the cross-validation"
     }
   ],
   "outputs": [

--- a/best-first-cv/metadata.json
+++ b/best-first-cv/metadata.json
@@ -25,13 +25,19 @@
       "name": "options",
       "type": "map",
       "default": {},
-      "descript": "Additional configuration options for the models"
+      "description": "Additional configuration options for the models"
     },
     {
       "name": "k-folds",
       "type": "number",
       "default": 5,
-      "descript": "Number of k-folds in the cross-validation"
+      "description": "Number of k-folds in the cross-validation"
+    },
+    {
+      "name": "pre-selected",
+      "type": "list",
+      "default": [],
+      "description": "List of field IDs to be pre-selected"
     }
   ],
   "outputs": [

--- a/best-first-cv/readme.md
+++ b/best-first-cv/readme.md
@@ -13,9 +13,19 @@ using a greedy algorithm:
   - Greedily select the feature `f'` with the best performance and add
     it to S
 
-The script takes as inputs the dataset to use and the number of
-features (that is, dataset fields) to return and yields as output a
-list of the `n` selected features, as field identifiers.
+The script takes as inputs
+
+- the dataset to use
+- the number of features (that is, dataset fields) to return
+- the objective field (target)
+- the configuration options for the models
+- the number of k-folds to use in the cross-validation
+- the subset of pre-selected features that will be used to append any other
+  available feature
+
+and yields as output a
+list of the `n` selected features, as field identifiers plus the subsets
+and evaluations for each iteration step.
 
 To select the best performance, the script uses the metric
 `average_phi` in the evaluations it performs, which is only available

--- a/best-first-cv/readme.md
+++ b/best-first-cv/readme.md
@@ -1,0 +1,27 @@
+# Best-first feature selection for classifications with cross-validation
+
+Script to select the `n` best features for modeling a given dataset,
+using a greedy algorithm:
+
+- Initialize the set `S` of selected features to the empty set
+
+- Split your dataset into training and test sets
+
+- For `i` in `1 ... n`:
+  - For each feature `f` not in `S`, model and evaluate with feature
+    set `S + f`
+  - Greedily select the feature `f'` with the best performance and add
+    it to S
+
+The script takes as inputs the dataset to use and the number of
+features (that is, dataset fields) to return and yields as output a
+list of the `n` selected features, as field identifiers.
+
+To select the best performance, the script uses the metric
+`average_phi` in the evaluations it performs, which is only available
+for classification problems.  Therefore, the script is only valid for
+categorical objective fields.
+
+You can set the configuration for the model to be used in the analysis in the
+`options` variable. For instance, if you set {"number_of_models": 2} an
+ensemble will be used.

--- a/best-first-cv/script.whizzml
+++ b/best-first-cv/script.whizzml
@@ -63,23 +63,20 @@
                           model-options
                           evaluation-options
                           delete-resources)
-  (log-info "*** " model-options)
   (let (dataset (fetch (k-fold-datasets 0))
         dataset-name (dataset "name" false))
     (check-dataset-objective-id objective-id dataset)
     (let (objective-name (get-objective-name dataset objective-id)
-          _ (log-info "*** pre evaluations")
           evaluations (create-k-evaluations k-fold-datasets
                                             objective-name
                                             dataset-name
                                             model-options
                                             evaluation-options
                                             delete-resources)
-          _ (log-info "*** post evaluations")
           ;; commented out till wintermute's new version
           ;; evaluations-average (create-and-wait-evaluation {"evaluations" evaluations})
           average-phi (get-average-phi evaluations)
-          _ (log-info "*** average phi:" average-phi))
+          _ (log-info "average phi:" average-phi))
       (when delete-resources
         (map safe-delete evaluations))
       average-phi)))
@@ -163,7 +160,6 @@
 ;; Output: (string) Checked objective field ID
 (define (check-dataset-objective-id objective-id dataset)
   (let (fields (dataset "fields" {})
-        _ (log-info "*** objective:" objective-id)
         objective-ids (choosable-objective-ids fields))
     (when (not (member? objective-id objective-ids))
       (raise {"message" (str "Failed to find the objective ID in the dataset"
@@ -251,17 +247,11 @@
 ;; Output: (list) model IDs
 ;;
 (define (create-k-models type multidatasets objective-name model-options)
-  (for (multidataset (reverse multidatasets))
-    (log-info "** type " type)
-    (log-info "** md " multidataset)
-    (log-info "** model-options: " model-options)
-    (log-info "** objective_field: " objective-name)
-    (let (model (create type
-                  (merge {"datasets" multidataset
-                          "objective_field" objective-name}
-                          model-options)))
-      (log-info "** creating model: " model)
-      (wait model))))
+  (wait* (for (multidataset (reverse multidatasets))
+            (create type
+                    (merge {"datasets" multidataset
+                            "objective_field" objective-name}
+                            model-options)))))
 
 
 ;; create-k-evaluations
@@ -298,7 +288,6 @@
         type (if (or (> number-of-models 1)
                      boosting?) "ensemble" "model")
         multidatasets (map last k-fold-pairs)
-        _ (log-info "*** multidatasets" multidatasets)
         models (cond (> number-of-models 1)
                      (create-k-models type
                                       multidatasets
@@ -318,12 +307,10 @@
                                       multidatasets
                                       objective-name
                                       model-options))
-        _ (log-info "*** models" models)
         evaluations (iterate (es []
                               id dataset-ids
                               mid models
                               idx (range 1 (+ 1 (count dataset-ids))))
-                      (log-info "*** evaluating " mid idx)
                       (let (name (str "Evaluation tested with subset "
                                       idx
                                       " of " dataset-name)
@@ -422,7 +409,6 @@
 ;; Output: (boolean) true if successful, false if not
 ;;
 (define (safe-delete id)
-  (log-info "*** deleting id: " id)
   (try (delete id)
        (catch e
          (log-info (str "Error deleting resource " id " ignored"))

--- a/best-first-cv/script.whizzml
+++ b/best-first-cv/script.whizzml
@@ -83,6 +83,12 @@
       average-phi)))
 
 
+(define (safe-create type args)
+  (try
+    (create type args)
+    (catch e
+      (create type args))))
+
 (define (get-average-phi evaluations)
   (/ (iterate (acc 0 ev evaluations)
        (+ acc ((fetch ev) ["result" "model" "average_phi"])))
@@ -193,11 +199,12 @@
 ;;
 (define (create-k-folds dataset-id k-folds)
   (let (k-fold-fn (lambda (x)
-                    (create-dataset {"origin_dataset" dataset-id
-                                     "row_offset" x
-                                     "row_step" k-folds
-                                     "new_fields" [{"name" "k_fold"
-                                                    "field" (str x)}]}))
+                    (safe-create "dataset"
+                                 {"origin_dataset" dataset-id
+                                  "row_offset" x
+                                  "row_step" k-folds
+                                  "new_fields" [{"name" "k_fold"
+                                                 "field" (str x)}]}))
         dataset-ids (map k-fold-fn (range 0 k-folds)))
     (wait* dataset-ids)))
 
@@ -249,10 +256,10 @@
 ;;
 (define (create-k-models type multidatasets objective-name model-options)
   (wait* (for (multidataset multidatasets)
-            (create type
-                    (merge {"datasets" multidataset
-                            "objective_field" objective-name}
-                            model-options)))))
+            (safe-create type
+                         (merge {"datasets" multidataset
+                                 "objective_field" objective-name}
+                                model-options)))))
 
 
 ;; create-k-evaluations
@@ -316,7 +323,10 @@
                                       idx
                                       " of " dataset-name)
                             opts (assoc evaluation-options "name" name))
-                       (append es (create-evaluation id mid opts)))))
+                       (append es (safe-create "evaluation"
+                                               (merge {"dataset" id
+                                                       "model" mid}
+                                                      opts))))))
     (wait* evaluations)
     (when delete-resources
       (map safe-delete models))

--- a/best-first-cv/script.whizzml
+++ b/best-first-cv/script.whizzml
@@ -1,8 +1,7 @@
-(define K-FOLDS 5)
-
 ;; This code will eventually be defined as a library.
 
 (define MODEL_OPTIONS ["balance_objective"
+                       "input_fields"
                        "missing_splits"
                        "pruning"
                        "weight_field"
@@ -21,6 +20,7 @@
                                           "randomize"
                                           "seed"]))
 (define LOGISTIC_OPTIONS ["balance_fields"
+                          "input_fields"
                           "bias"
                           "c"
                           "missing_numerics"
@@ -31,6 +31,7 @@
                           "regularization"
                           "seed"])
 (define EVALUATION_OPTIONS ["sample_rate"
+                            "input_fields"
                             "out_of_bag"
                             "range"
                             "replacement"
@@ -75,11 +76,18 @@
                                             evaluation-options
                                             delete-resources)
           _ (log-info "*** post evaluations")
-          evaluations-average (create-and-wait-evaluation {"evaluations" evaluations})
-          _ (log-info "*** average phi:" ((fetch evaluations-average) ["result" "model" "average_phi"])))
+          ;; commented out till wintermute's new version
+          ;; evaluations-average (create-and-wait-evaluation {"evaluations" evaluations})
+          average-phi (get-average-phi evaluations)
+          _ (log-info "*** average phi:" average-phi))
       (when delete-resources
         (map safe-delete evaluations))
       evaluations-average)))
+
+
+(define (get-average-phi evaluations)
+  (iterate (acc 0 ev evaluations)
+    (+ acc (ev ["result" "model" "average_phi"]))))
 
 ;; check-resource-id
 ;;
@@ -431,9 +439,9 @@
 ;; evaluate them, and add the feature corresponding to the best
 ;; cv to the running set of features.  Stop when you reach the
 ;; target number, or you run out of features.
-(define (select-features dataset-id nfeatures objective-id options)
+(define (select-features dataset-id nfeatures objective-id options k-folds)
   (let (obj-id (get-objective dataset-id objective-id)
-        k-fold-datasets (create-k-folds dataset-id K-FOLDS)
+        k-fold-datasets (create-k-folds dataset-id k-folds)
         input-ids (default-inputs dataset-id obj-id))
     (loop (selected []
            potentials input-ids)
@@ -506,4 +514,4 @@
     obj-id))
 
 (define output-features
-  (select-features dataset-id n objective-id options))
+  (select-features dataset-id n objective-id options k-folds))

--- a/best-first-cv/script.whizzml
+++ b/best-first-cv/script.whizzml
@@ -76,7 +76,8 @@
           ;; commented out till wintermute's new version
           ;; evaluations-average (create-and-wait-evaluation {"evaluations" evaluations})
           average-phi (get-average-phi evaluations)
-          _ (log-info "average phi:" average-phi))
+          _ (log-info "model options: " model-options)
+          _ (log-info "average phi: " average-phi))
       (when delete-resources
         (map safe-delete evaluations))
       average-phi)))

--- a/best-first-cv/script.whizzml
+++ b/best-first-cv/script.whizzml
@@ -421,20 +421,27 @@
 
 
 
-
 ;; Do best-first feature selection.  Given a dataset and a target
 ;; number of features iteratively construct models for each feature,
 ;; evaluate them, and add the feature corresponding to the best
 ;; cv to the running set of features.  Stop when you reach the
 ;; target number, or you run out of features.
-(define (select-features dataset-id nfeatures objective-id options k-folds)
+(define (select-features dataset-id
+                         nfeatures
+                         objective-id
+                         options
+                         k-folds
+                         pre-selected)
   (let (obj-id (get-objective dataset-id objective-id)
         k-fold-datasets (create-k-folds dataset-id k-folds)
-        ;; input-ids (default-inputs dataset-id obj-id)
-        important-ids (important-fields dataset-id obj-id))
-    (loop (selected []
-           potentials important-ids
+        input-ids (default-inputs dataset-id obj-id)
+        important-ids (important-fields dataset-id obj-id)
+        _ (log-info important-ids)
+        potentials (make-complementary important-ids pre-selected))
+    (loop (selected pre-selected
+           potentials potentials
            queue [])
+
       (if (or (>= (count selected) nfeatures) (empty? potentials))
         (response dataset-id k-fold-datasets selected queue)
         (let (_ (log-info "Making new candidates...")
@@ -449,15 +456,20 @@
                                              potentials)
               _ (log-info "Next selected feature: " (next-feat-info "feature")))
           (recur (append selected (next-feat-info "feature"))
-                 (filter (lambda (id) (not (= (id "feature")
-                                              (next-feat-info "feature"))))
-                         potentials)
+                 (make-complementary potentials [(next-feat-info "feature")])
                  (cons {"features" (append selected
                                            (next-feat-info "feature"))
                               "phi" (next-feat-info "phi")} queue)))))))
 
 ;; A simple function to get the max value in a list
 (define (get-max xs) (reduce (lambda (x y) (if (> x y) x y)) (head xs) xs))
+
+
+;; Filters the features in one list to be complementary with the ones in
+;; another list
+(define (make-complementary y-list x-list)
+  (iterate (acc y-list x x-list)
+    (filter (lambda (y) (not (= x (y "feature")))) acc)))
 
 
 ;; Clean the created datasets and deliver a human-readable response
@@ -536,4 +548,4 @@
     obj-id))
 
 (define output-features
-  (select-features dataset-id n objective-id options k-folds))
+  (select-features dataset-id n objective-id options k-folds pre-selected))

--- a/best-first-cv/script.whizzml
+++ b/best-first-cv/script.whizzml
@@ -82,7 +82,7 @@
           _ (log-info "*** average phi:" average-phi))
       (when delete-resources
         (map safe-delete evaluations))
-      evaluations-average)))
+      average-phi)))
 
 
 (define (get-average-phi evaluations)
@@ -495,7 +495,8 @@
                                                      e-attrs
                                                      {}
                                                      true)) all-reqs)
-        vs (map (lambda (ev) (ev ["result" "model" "average_phi"] 0)) cvs)
+        ;;vs (map (lambda (ev) (ev ["result" "model" "average_phi"] 0)) cvs)
+        vs cvs
         value-map (make-map potentials vs)
         max-val (get-max vs)
         choose-best (lambda (id) (and (= max-val (value-map id)) id)))

--- a/best-first-cv/script.whizzml
+++ b/best-first-cv/script.whizzml
@@ -434,7 +434,7 @@
     (loop (selected []
            potentials input-ids)
       (if (or (>= (count selected) nfeatures) (empty? potentials))
-        (response dataset-id selected)
+        (response dataset-id k-fold-datasets selected)
         (let (_ (log-info "Making new candidates...")
               candidates (make-candidates selected potentials)
               _ (log-info "Selecting feature..." candidates)

--- a/best-first-cv/script.whizzml
+++ b/best-first-cv/script.whizzml
@@ -434,7 +434,7 @@
     (loop (selected []
            potentials input-ids)
       (if (or (>= (count selected) nfeatures) (empty? potentials))
-        (feature-names dataset-id selected)
+        (response dataset-id selected)
         (let (_ (log-info "Making new candidates...")
               candidates (make-candidates selected potentials)
               _ (log-info "Selecting feature..." candidates)
@@ -449,6 +449,13 @@
 
 ;; A simple function to get the max value in a list
 (define (get-max xs) (reduce (lambda (x y) (if (> x y) x y)) (head xs) xs))
+
+
+;; Clean the created datasets and deliver a human-readable response
+(define (response dataset-id k-fold-datasets selected)
+  (map safe-delete k-fold-datasets)
+  (feature-names dataset-id selected))
+
 
 ;; Get feature names given ids
 (define (feature-names dataset-id ids)

--- a/best-first-cv/script.whizzml
+++ b/best-first-cv/script.whizzml
@@ -247,7 +247,7 @@
 ;; Output: (list) model IDs
 ;;
 (define (create-k-models type multidatasets objective-name model-options)
-  (wait* (for (multidataset (reverse multidatasets))
+  (wait* (for (multidataset multidatasets)
             (create type
                     (merge {"datasets" multidataset
                             "objective_field" objective-name}

--- a/best-first-cv/script.whizzml
+++ b/best-first-cv/script.whizzml
@@ -430,31 +430,41 @@
 (define (select-features dataset-id nfeatures objective-id options k-folds)
   (let (obj-id (get-objective dataset-id objective-id)
         k-fold-datasets (create-k-folds dataset-id k-folds)
-        input-ids (default-inputs dataset-id obj-id))
+        ;; input-ids (default-inputs dataset-id obj-id)
+        important-ids (important-fields dataset-id obj-id))
     (loop (selected []
-           potentials input-ids)
+           potentials important-ids
+           queue [])
       (if (or (>= (count selected) nfeatures) (empty? potentials))
-        (response dataset-id k-fold-datasets selected)
+        (response dataset-id k-fold-datasets selected queue)
         (let (_ (log-info "Making new candidates...")
-              candidates (make-candidates selected potentials)
+              candidates (make-candidates selected
+                                          (map (lambda (x) (x "feature"))
+                                          potentials))
               _ (log-info "Selecting feature..." candidates)
-              next-feat (select-feature k-fold-datasets
-                                        obj-id
-                                        options
-                                        candidates
-                                        potentials)
-              _ (log-info "Next selected feature: " next-feat))
-          (recur (cons next-feat selected)
-                 (filter (lambda (id) (not (= id next-feat))) potentials)))))))
+              next-feat-info (select-feature k-fold-datasets
+                                             obj-id
+                                             options
+                                             candidates
+                                             potentials)
+              _ (log-info "Next selected feature: " (next-feat-info "feature")))
+          (recur (append selected (next-feat-info "feature"))
+                 (filter (lambda (id) (not (= (id "feature")
+                                              (next-feat-info "feature"))))
+                         potentials)
+                 (cons {"features" (append selected
+                                           (next-feat-info "feature"))
+                              "phi" (next-feat-info "phi")} queue)))))))
 
 ;; A simple function to get the max value in a list
 (define (get-max xs) (reduce (lambda (x y) (if (> x y) x y)) (head xs) xs))
 
 
 ;; Clean the created datasets and deliver a human-readable response
-(define (response dataset-id k-fold-datasets selected)
+(define (response dataset-id k-fold-datasets selected queue)
   (map safe-delete k-fold-datasets)
-  (feature-names dataset-id selected))
+  {"selected-fields" (feature-names dataset-id selected)
+   "iterations-info" queue})
 
 
 ;; Get feature names given ids
@@ -470,6 +480,20 @@
     (filter (lambda (k) (and (fields [k "preferred"] false) (not (= obj-id k))))
             fids)))
 
+
+;; Get the set of input fields for this dataset by using the importance of the
+;; fields in a random decision forest
+(define (important-fields dataset-id obj-id)
+  (let (ensemble-id (create-and-wait-ensemble dataset-id
+                                              {"randomize" true
+                                               "objective_field" obj-id})
+        ensemble (fetch ensemble-id)
+        importance (ensemble "importance")
+        importance (for (key (keys importance))
+                     {"feature" key "phi" (importance key)}))
+    (reverse (sort-by-key "phi" importance))))
+
+
 ;; Make a list of input fields candidates given the potential
 ;; features in potentials.
 (define (make-candidates selected potentials)
@@ -484,6 +508,7 @@
 (define (select-feature k-fold-datasets objective-id options candidates potentials)
   (let (make-attrs (lambda (inp) (merge {"input_fields" inp}
                                         options))
+        potentials (map (lambda (x) (x "feature")) potentials)
         all-reqs (map make-attrs candidates)
         cvs (map (lambda (e-attrs) (cross-validation k-fold-datasets
                                                      objective-id
@@ -495,7 +520,8 @@
         value-map (make-map potentials vs)
         max-val (get-max vs)
         choose-best (lambda (id) (and (= max-val (value-map id)) id)))
-    (some choose-best potentials)))
+    {"feature" (some choose-best potentials)
+     "phi" max-val}))
 
 ;; Retrieves and checks whether the objective field of the given
 ;; dataset is categorical, raising an error otherwise.

--- a/best-first-cv/script.whizzml
+++ b/best-first-cv/script.whizzml
@@ -87,7 +87,7 @@
 
 (define (get-average-phi evaluations)
   (iterate (acc 0 ev evaluations)
-    (+ acc (ev ["result" "model" "average_phi"]))))
+    (+ acc ((fetch ev) ["result" "model" "average_phi"]))))
 
 ;; check-resource-id
 ;;

--- a/best-first-cv/script.whizzml
+++ b/best-first-cv/script.whizzml
@@ -75,9 +75,9 @@
                                             delete-resources)
           ;; commented out till wintermute's new version
           ;; evaluations-average (create-and-wait-evaluation {"evaluations" evaluations})
-          average-phi (get-average-phi evaluations)
-          _ (log-info "model options: " model-options)
-          _ (log-info "average phi: " average-phi))
+          average-phi (get-average-phi evaluations))
+      (log-info "model options: " model-options)
+      (log-info "average phi: " average-phi)
       (when delete-resources
         (map safe-delete evaluations))
       average-phi)))
@@ -105,7 +105,7 @@
 ;;
 ;; Output: (string) Checked resource ID
 (define (check-resource-id resource-id type)
-  (when (not (string? resource-id))
+  (when (not (resource-id? resource-id))
     (raise {"message" (str "Resource ID string expected. Found "
                            resource-id " instead.")
             "code" 101}))
@@ -219,27 +219,10 @@
 ;; Output: (list) List of pairs [hold-out dataset, multidataset with the rest]
 ;;
 (define (pair-k-folds dataset-ids)
-  (map (lambda(x)
-         [(nth dataset-ids x)
-          (concat (take x dataset-ids)
-          (drop (+ x 1) dataset-ids))])
+  (map (lambda(x) [(nth dataset-ids x) (concat (take x dataset-ids)
+                                               (drop (+ x 1) dataset-ids))])
        (range 0 (count dataset-ids))))
 
-
-;; select-map-keys
-;;
-;; Filters the keys in a map, keeping only the ones that appear in the list.
-;;
-;; Inputs:
-;;   map: (map) Key, value maps
-;;   keys-list: (list) List of keys to be kept in the map
-;; Output: (map) filtered map with only the keys in the keys-list
-;;
-(define (select-map-keys a-map keys-list)
-  (reduce (lambda (x y) (let (value (a-map y false))
-                          (cond value (assoc x y value) x)))
-          {}
-          keys-list))
 
 ;; create-k-models
 ;;
@@ -286,13 +269,13 @@
         regularization (model-options "regularization" false)
         boosting? (not (empty? (model-options "boosting" {})))
         k-fold-pairs (pair-k-folds dataset-ids)
-        ensemble-options (select-map-keys model-options ENSEMBLE_OPTIONS)
-        boosted-ensemble-options (select-map-keys model-options
-                                                  BOOSTED_ENSEMBLE_OPTIONS)
-        model-options (select-map-keys model-options MODEL_OPTIONS)
-        logistic-options (select-map-keys model-options LOGISTIC_OPTIONS)
-        evaluation-options (select-map-keys evaluation-options
-                                            EVALUATION_OPTIONS)
+        ensemble-options (select-keys model-options ENSEMBLE_OPTIONS)
+        boosted-ensemble-options (select-keys model-options
+                                              BOOSTED_ENSEMBLE_OPTIONS)
+        model-options (select-keys model-options MODEL_OPTIONS)
+        logistic-options (select-keys model-options LOGISTIC_OPTIONS)
+        evaluation-options (select-keys evaluation-options
+                                        EVALUATION_OPTIONS)
         type (if (or (> number-of-models 1)
                      boosting?) "ensemble" "model")
         multidatasets (map last k-fold-pairs)
@@ -444,6 +427,10 @@
                          pre-selected)
   (let (obj-id (get-objective dataset-id objective-id)
         k-fold-datasets (create-k-folds dataset-id k-folds)
+        fields (resource-fields dataset-id)
+        pre-selected (map (lambda (x) ((find-field fields x) "id"))
+                          pre-selected)
+        _ (log-info pre-selected)
         input-ids (default-inputs dataset-id obj-id)
         important-ids (important-fields dataset-id obj-id)
         _ (log-info important-ids)
@@ -499,7 +486,7 @@
 (define (default-inputs dataset-id obj-id)
   (let (fields ((fetch dataset-id) "fields")
         fids (keys fields))
-    (filter (lambda (k) (and (fields [k "preferred"] false) (not (= obj-id k))))
+    (filter (lambda (k) (and (fields [k "preferred"] true) (not (= obj-id k))))
             fids)))
 
 
@@ -527,9 +514,12 @@
 ;; model ids corresponding to those features, select the best
 ;; potential feature by performing an evaluation on each model and
 ;; returning the feature with the best performance.
-(define (select-feature k-fold-datasets objective-id options candidates potentials)
-  (let (make-attrs (lambda (inp) (merge {"input_fields" inp}
-                                        options))
+(define (select-feature k-fold-datasets
+                        objective-id
+                        options
+                        candidates
+                        potentials)
+  (let (make-attrs (lambda (inp) (assoc options "input_fields" inp))
         potentials (map (lambda (x) (x "feature")) potentials)
         all-reqs (map make-attrs candidates)
         cvs (map (lambda (e-attrs) (cross-validation k-fold-datasets
@@ -551,7 +541,9 @@
   (let (obj-id (if (empty? obj-id)
                    (dataset-get-objective-id ds-id)
                    obj-id)
-        otype ((fetch ds-id) ["fields" obj-id "optype"] "missing"))
+        fields (resource-fields ds-id)
+        obj-id ((find-field fields obj-id) "id")
+        otype (fields [obj-id "optype"] "missing"))
     (when (not (= "categorical" otype))
       (raise (str "The dataset's objective field must be categorical, "
                   "but is " otype)))

--- a/best-first-cv/script.whizzml
+++ b/best-first-cv/script.whizzml
@@ -1,0 +1,509 @@
+(define K-FOLDS 5)
+
+;; This code will eventually be defined as a library.
+
+(define MODEL_OPTIONS ["balance_objective"
+                       "missing_splits"
+                       "pruning"
+                       "weight_field"
+                       "objective_weights"
+                       "node_threshold"])
+(define ENSEMBLE_OPTIONS (concat MODEL_OPTIONS
+                                 ["sample_rate"
+                                  "replacement"
+                                  "randomize"
+                                  "number_of_models"
+                                  "seed"]))
+(define BOOSTED_ENSEMBLE_OPTIONS (concat MODEL_OPTIONS
+                                         ["boosting"
+                                          "sample_rate"
+                                          "replacement"
+                                          "randomize"
+                                          "seed"]))
+(define LOGISTIC_OPTIONS ["balance_fields"
+                          "bias"
+                          "c"
+                          "missing_numerics"
+                          "default_numeric_value"
+                          "eps"
+                          "field_codings"
+                          "normalize"
+                          "regularization"
+                          "seed"])
+(define EVALUATION_OPTIONS ["sample_rate"
+                            "out_of_bag"
+                            "range"
+                            "replacement"
+                            "ordering"
+                            "seed"
+                            "missing_strategy"
+                            "combiner"])
+;; cross-validation
+;;
+;; creates k-fold cross-validation for a dataset
+;; Inputs:
+;;   dataset-id: (string) Dataset ID
+;;   k-folds: (integer) Number of folds
+;;   model-options: (map) Options to use in model/ensemble
+;;   evaluation-options: (map) Options to use in evaluation creation
+;;   delete-resources: (boolean) Whether to delete all intermediate resources
+;;
+;; Output: (map) Average of evaluations results
+;;
+;; Raises:
+;;  101: The dataset-id argument is not a string
+;;  102: The dataset-id is not a valid dataset ID
+;;  103: The k-folds argument is not an integer
+;;  104: The k-folds argument is not >= 2
+;;  106: The objective field ID is not in the selectable IDs list
+;;
+(define (cross-validation k-fold-datasets
+                          objective-id
+                          model-options
+                          evaluation-options
+                          delete-resources)
+  (log-info "*** " model-options)
+  (let (dataset (fetch (k-fold-datasets 0))
+        dataset-name (dataset "name" false))
+    (check-dataset-objective-id objective-id dataset)
+    (let (objective-name (get-objective-name dataset objective-id)
+          _ (log-info "*** pre evaluations")
+          evaluations (create-k-evaluations k-fold-datasets
+                                            objective-name
+                                            dataset-name
+                                            model-options
+                                            evaluation-options
+                                            delete-resources)
+          _ (log-info "*** post evaluations")
+          evaluations-average (create-and-wait-evaluation {"evaluations" evaluations})
+          _ (log-info "*** average phi:" ((fetch evaluations-average) ["result" "model" "average_phi"])))
+      (when delete-resources
+        (map safe-delete evaluations))
+      evaluations-average)))
+
+;; check-resource-id
+;;
+;; Validates that the argument is a resource ID and its type. Raises an error
+;; if otherwise.
+;;
+;; Inputs:
+;;   resource-id: (string) Resource ID
+;;   type: (string) Type of resource
+;;
+;; Output: (string) Checked resource ID
+(define (check-resource-id resource-id type)
+  (when (not (string? resource-id))
+    (raise {"message" (str "Resource ID string expected. Found "
+                           resource-id " instead.")
+            "code" 101}))
+  (when (not (= (resource-type resource-id) type))
+    (raise {"message" (str "Failed to find a correct " type " ID.")
+            "code" 102}))
+  resource-id)
+
+
+;; check-integer
+;;
+;; Validates that the argument is an integer. Raises error if otherwise.
+;;
+;; Inputs:
+;;  value: (number) Integer to be checked
+;;  minimum: (number) Minimum value (false if not set)
+;;  maximum: (number) Maximum value (false if not set)
+;;
+;; Output: (number) Checked integer
+(define (check-integer value minimum maximum)
+  (when (not (integer? value))
+    (raise {"message" (str "Integer value expected. Found " value " instead.")
+            "code" 103}))
+  (when (and minimum (< value minimum))
+    (raise {"message" (str "Minimum accepted value is " minimum ". " value
+                           " found.")
+            "code" 104}))
+  (when (and maximum (> value maximum))
+    (raise {"message" (str "Maximum accepted value is " maximum ". " value
+                           " found.")
+            "code" 105}))
+  value)
+
+;; choosable-objective-ids
+;;
+;; List of IDs of the fields in the dataset that can be chosen as objective
+;; field.
+;;
+;; Inputs:
+;;  fields: (map) Fields structure
+;; Output: (list) list of field IDs
+(define (choosable-objective-ids fields)
+  (let (field-val (lambda (fid k) (fields [fid k] false))
+        objective-types ["categorical", "numeric"]
+        pref? (lambda (k) (field-val k "preferred"))
+        pred? (lambda (k) (member? (field-val k "optype") objective-types)))
+    (filter (lambda (x) (and (pref? x) (pred? x))) (keys fields))))
+
+
+;; check-dataset-objective-id
+;;
+;; Validates that the argument is a valid objective id in the reference
+;; dataset.
+;;
+;; Inputs:
+;;  objective-id: (string) ID of the objective field
+;;  dataset: (map) Dataset resource information
+;;
+;; Output: (string) Checked objective field ID
+(define (check-dataset-objective-id objective-id dataset)
+  (let (fields (dataset "fields" {})
+        _ (log-info "*** objective:" objective-id)
+        objective-ids (choosable-objective-ids fields))
+    (when (not (member? objective-id objective-ids))
+      (raise {"message" (str "Failed to find the objective ID in the dataset"
+                             " choosable fields.")
+              "code" 106}))))
+
+;; get-objective-name
+;;
+;; Returns the name of the field used as objective field
+;;
+;; Inputs:
+;;  dataset: (map) Dataset resource info
+;;  objective-id: (string) ID of the objective field
+;;
+;; Outputs: (string) Name of the objective field
+
+(define (get-objective-name dataset objective-id)
+  (dataset ["fields" objective-id "name"] false))
+
+
+;; create-k-folds
+;;
+;; creating k-fold splits from a dataset
+;;
+;; Inputs:
+;;   dataset-id: (string) Dataset ID
+;;   k-folds: (integer) Number of folds
+;;
+;; Output: (list) List of dataset IDs
+;;
+(define (create-k-folds dataset-id k-folds)
+  (let (k-fold-fn (lambda (x)
+                    (create-dataset {"origin_dataset" dataset-id
+                                     "row_offset" x
+                                     "row_step" k-folds
+                                     "new_fields" [{"name" "k_fold"
+                                                    "field" (str x)}]}))
+        dataset-ids (map k-fold-fn (range 0 k-folds)))
+    (wait* dataset-ids)))
+
+;; pair-k-folds
+;;
+;; Builds a list of pairs of hold-out and complementary datasets for all
+;; the k-fold dataset IDs.
+;;
+;; Inputs:
+;;   dataset-ids: (list) List of the k-fold dataset IDs
+;;
+;; Output: (list) List of pairs [hold-out dataset, multidataset with the rest]
+;;
+(define (pair-k-folds dataset-ids)
+  (map (lambda(x)
+         [(nth dataset-ids x)
+          (concat (take x dataset-ids)
+          (drop (+ x 1) dataset-ids))])
+       (range 0 (count dataset-ids))))
+
+
+;; select-map-keys
+;;
+;; Filters the keys in a map, keeping only the ones that appear in the list.
+;;
+;; Inputs:
+;;   map: (map) Key, value maps
+;;   keys-list: (list) List of keys to be kept in the map
+;; Output: (map) filtered map with only the keys in the keys-list
+;;
+(define (select-map-keys a-map keys-list)
+  (reduce (lambda (x y) (let (value (a-map y false))
+                          (cond value (assoc x y value) x)))
+          {}
+          keys-list))
+
+;; create-k-models
+;;
+;; Creates the models for a set of k-fold datasets
+;;
+;; Inputs:
+;;   type: (string) type of model (model or ensemble)
+;;   multidatasets: (list) List of lists of datset IDs once a k-fold is
+;;                         excluded
+;;   objective-name: (string) name of the objective field
+;;   model-options: (map) Options for the model or ensemble
+;;
+;; Output: (list) model IDs
+;;
+(define (create-k-models type multidatasets objective-name model-options)
+  (for (multidataset (reverse multidatasets))
+    (log-info "** type " type)
+    (log-info "** md " multidataset)
+    (log-info "** model-options: " model-options)
+    (log-info "** objective_field: " objective-name)
+    (let (model (create type
+                  (merge {"datasets" multidataset
+                          "objective_field" objective-name}
+                          model-options)))
+      (log-info "** creating model: " model)
+      (wait model))))
+
+
+;; create-k-evaluations
+;;
+;; Creates the models/ensembles and evaluations for a set of k-fold datasets
+;;
+;; Inputs:
+;;   dataset-ids: (list) List of the k-fold dataset IDs
+;;   objective-name: (string) Objective field name
+;;   dataset-name: (string) Name of the origin dataset
+;;   model-options: (map) Options used to build the models/ensembles
+;;   evaluation-options: (map) Options used to build evaluations
+;;   delete-resources: (boolean) Whether to delete all intermediate resources
+;;
+;; Output: (list) List of evaluation IDs
+;;
+(define (create-k-evaluations dataset-ids
+                              objective-name
+                              dataset-name
+                              model-options
+                              evaluation-options
+                              delete-resources)
+  (let (number-of-models (model-options "number_of_models" 1)
+        regularization (model-options "regularization" false)
+        boosting? (not (empty? (model-options "boosting" {})))
+        k-fold-pairs (pair-k-folds dataset-ids)
+        ensemble-options (select-map-keys model-options ENSEMBLE_OPTIONS)
+        boosted-ensemble-options (select-map-keys model-options
+                                                  BOOSTED_ENSEMBLE_OPTIONS)
+        model-options (select-map-keys model-options MODEL_OPTIONS)
+        logistic-options (select-map-keys model-options LOGISTIC_OPTIONS)
+        evaluation-options (select-map-keys evaluation-options
+                                            EVALUATION_OPTIONS)
+        type (if (or (> number-of-models 1)
+                     boosting?) "ensemble" "model")
+        multidatasets (map last k-fold-pairs)
+        _ (log-info "*** multidatasets" multidatasets)
+        models (cond (> number-of-models 1)
+                     (create-k-models type
+                                      multidatasets
+                                      objective-name
+                                      ensemble-options)
+                     regularization
+                     (create-k-models type
+                                      multidatasets
+                                      objective-name
+                                      logistic-options)
+                     boosting?
+                     (create-k-models type
+                                      multidatasets
+                                      objective-name
+                                      boosted-ensemble-options)
+                     (create-k-models type
+                                      multidatasets
+                                      objective-name
+                                      model-options))
+        _ (log-info "*** models" models)
+        evaluations (iterate (es []
+                              id dataset-ids
+                              mid models
+                              idx (range 1 (+ 1 (count dataset-ids))))
+                      (log-info "*** evaluating " mid idx)
+                      (let (name (str "Evaluation tested with subset "
+                                      idx
+                                      " of " dataset-name)
+                            opts (assoc evaluation-options "name" name))
+                       (append es (create-evaluation id mid opts)))))
+    (wait* evaluations)
+    (when delete-resources
+      (map safe-delete models))
+    evaluations))
+
+;; Script
+
+;;get-model-options
+;;
+;; maps the options to be used in models
+;; Inputs:
+;;   missing-splits: (boolen) Sets the missing_splits flag
+;;   stat-pruning: (boolean) Sets the statistical pruning flag
+;;   balance-objective: (boolean) Sets the balance_objective flag
+;;   weight-field: (string) ID of the field to be used as weight (weight_field)
+;;   objetive-weights: (list) List of values to be used as objective_weights
+;;   node-threshold: (integer) Maximum number of nodes in the model
+;; Output: (map) options map
+;;
+(define (get-model-options missing-splits
+                           stat-pruning
+                           balance-objective
+                           weight-field
+                           objective-weights
+                           node-threshold)
+  (let (options {}
+    options (assoc options "missing_splits" missing-splits)
+    options (assoc options "stat_pruning" stat-pruning)
+    options (assoc options "balance_objective" balance-objective)
+    options (if (not (empty? weight-field))
+                (assoc options "weight_field" weight-field)
+                options)
+    options (if (not (empty? objective-weights))
+                (assoc options "objective_weights" objective-weights)
+                options)
+    options (if (not (= node-threshold -1))
+                (assoc options "node_threshold" node-threshold)
+                options))
+    options))
+
+;;get-ensemble-options
+;;
+;; maps the options to be used in esembles
+;; Inputs:
+;;   number-of-models: (integer) Number of models in the ensemble
+;;   missing-splits: (boolean) Sets the missing_splits flag
+;;   stat-pruning: (boolean) Sets the pruning flag
+;;   balance-objective: (boolean) Sets the balance_objective flag
+;;   weight-field: (string) ID of the field to be used as weight (weight_field)
+;;   objective-weights: (list) List of values to be used as objective_weights
+;;   node-threshold: (integer) Maximum number of nodes in the model
+;;   sample-rate: (float) Percentage of instances used as sample
+;;   replacement: (boolean) Sets the replacement flag
+;;   randomize: (boolean) Sets the randomize flag
+;;   seed: (string) Seed used in random samplings
+;; Output: (map) options map
+;;
+(define (get-ensemble-options number-of-models
+                              missing-splits
+                              stat-pruning
+                              balance-objective
+                              weight-field
+                              objective-weights
+                              node-threshold
+                              sample-rate
+                              replacement
+                              randomize
+                              seed)
+  (let (options (get-model-options missing-splits
+                                   stat-pruning
+                                   balance-objective
+                                   weight-field
+                                   objective-weights
+                                   node-threshold)
+        options (if (> number-of-models 1)
+                    (assoc options "number_of_models" number-of-models)
+                    (assoc options "number_of_models" 10))
+        options (merge options {"sample_rate" sample-rate
+                                "replacement" replacement
+                                "randomize" randomize}))
+    (if (empty? seed)
+        options
+        (assoc options "seed" seed))))
+
+;; safe-delete
+;;
+;; deletes resources ignoring errors
+;; Inputs:
+;;   id: (resource-id) resource to be deleted
+;;
+;; Output: (boolean) true if successful, false if not
+;;
+(define (safe-delete id)
+  (log-info "*** deleting id: " id)
+  (try (delete id)
+       (catch e
+         (log-info (str "Error deleting resource " id " ignored"))
+         false)))
+
+
+
+;-----------------------------------------------------------------
+
+
+
+
+;; Do best-first feature selection.  Given a dataset and a target
+;; number of features iteratively construct models for each feature,
+;; evaluate them, and add the feature corresponding to the best
+;; cv to the running set of features.  Stop when you reach the
+;; target number, or you run out of features.
+(define (select-features dataset-id nfeatures objective-id options)
+  (let (obj-id (get-objective dataset-id objective-id)
+        k-fold-datasets (create-k-folds dataset-id K-FOLDS)
+        input-ids (default-inputs dataset-id obj-id))
+    (loop (selected []
+           potentials input-ids)
+      (if (or (>= (count selected) nfeatures) (empty? potentials))
+        (feature-names dataset-id selected)
+        (let (_ (log-info "Making new candidates...")
+              candidates (make-candidates selected potentials)
+              _ (log-info "Selecting feature..." candidates)
+              next-feat (select-feature k-fold-datasets
+                                        obj-id
+                                        options
+                                        candidates
+                                        potentials)
+              _ (log-info "Next selected feature: " next-feat))
+          (recur (cons next-feat selected)
+                 (filter (lambda (id) (not (= id next-feat))) potentials)))))))
+
+;; A simple function to get the max value in a list
+(define (get-max xs) (reduce (lambda (x y) (if (> x y) x y)) (head xs) xs))
+
+;; Get feature names given ids
+(define (feature-names dataset-id ids)
+  (let (fields ((fetch dataset-id) "fields"))
+    (map (lambda (id) (fields [id "name"])) ids)))
+
+;; Get the default set of input fields for this dataset (all preferred
+;; fields minus the objective field).
+(define (default-inputs dataset-id obj-id)
+  (let (fields ((fetch dataset-id) "fields")
+        fids (keys fields))
+    (filter (lambda (k) (and (fields [k "preferred"] false) (not (= obj-id k))))
+            fids)))
+
+;; Make a list of input fields candidates given the potential
+;; features in potentials.
+(define (make-candidates selected potentials)
+  (let (make-req (lambda (fid)
+                   (cons fid selected)))
+    (map make-req potentials)))
+
+;; Given a set of dataset folds, a list of potential features, and a list of
+;; model ids corresponding to those features, select the best
+;; potential feature by performing an evaluation on each model and
+;; returning the feature with the best performance.
+(define (select-feature k-fold-datasets objective-id options candidates potentials)
+  (let (make-attrs (lambda (inp) (merge {"input_fields" inp}
+                                        options))
+        all-reqs (map make-attrs candidates)
+        cvs (map (lambda (e-attrs) (cross-validation k-fold-datasets
+                                                     objective-id
+                                                     e-attrs
+                                                     {}
+                                                     true)) all-reqs)
+        vs (map (lambda (ev) (ev ["result" "model" "average_phi"] 0)) cvs)
+        value-map (make-map potentials vs)
+        max-val (get-max vs)
+        choose-best (lambda (id) (and (= max-val (value-map id)) id)))
+    (some choose-best potentials)))
+
+;; Retrieves and checks whether the objective field of the given
+;; dataset is categorical, raising an error otherwise.
+(define (get-objective ds-id obj-id)
+  (let (obj-id (if (empty? obj-id)
+                   (dataset-get-objective-id ds-id)
+                   obj-id)
+        otype ((fetch ds-id) ["fields" obj-id "optype"] "missing"))
+    (when (not (= "categorical" otype))
+      (raise (str "The dataset's objective field must be categorical, "
+                  "but is " otype)))
+    obj-id))
+
+(define output-features
+  (select-features dataset-id n objective-id options))

--- a/best-first-cv/script.whizzml
+++ b/best-first-cv/script.whizzml
@@ -86,8 +86,9 @@
 
 
 (define (get-average-phi evaluations)
-  (iterate (acc 0 ev evaluations)
-    (+ acc ((fetch ev) ["result" "model" "average_phi"]))))
+  (/ (iterate (acc 0 ev evaluations)
+       (+ acc ((fetch ev) ["result" "model" "average_phi"])))
+     (count evaluations)))
 
 ;; check-resource-id
 ;;

--- a/best-first-cv/test/test.sh
+++ b/best-first-cv/test/test.sh
@@ -35,8 +35,14 @@ if [[ " $file_content " =~ $regex ]]
         echo "best-first-cv KO:\n $file_content"
         exit 1
 fi
+
+
 # remove the created resources
-run_bigmler delete --from-dir cmd --output-dir cmd_del
+run_bigmler delete --from-dir cmd/pre_test --output-dir cmd_del
 run_bigmler delete --from-dir .build --output-dir cmd_del
+cat cmd/results/execution | while read execution
+do
+run_bigmler delete --id "$execution" --output-dir cmd_del
+done
 rm -f -R test_inputs.json cmd cmd_del
 rm -f -R .build .bigmler*

--- a/best-first-cv/test/test.sh
+++ b/best-first-cv/test/test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+source ../../test-utils.sh
+
+rm -f -R cmd_del
+rm -f -R cmd
+rm -f -R .build
+
+log "-------------------------------------------------------"
+log "Test for best-first-cv script"
+run_bigmler whizzml --package-dir ../ --output-dir ./.build
+# creating the resources needed to run the test
+run_bigmler --train s3://bigml-public/csv/diabetes.csv --no-model \
+            --project "Whizzml examples tests" --output-dir cmd/pre_test
+# building the inputs for the test
+prefix='[["dataset-id", "'
+suffix='"], ["n", 2], ["objective-id" ,"diabetes"], ["pre-selected", ["plasma glucose"]]]'
+text=''
+cat cmd/pre_test/dataset | while read datasets
+do
+echo "$prefix$datasets$suffix" > "test_inputs.json"
+done
+log "Testing best-first-cv script -------------------------------"
+# running the execution with the given inputs
+run_bigmler execute --scripts .build/scripts --inputs test_inputs.json \
+                    --output-dir cmd/results --verbosity 1
+# check the outputs
+declare file="cmd/results/whizzml_results.json"
+declare regex="\"selected-fields\": \[\"plasma glucose\", \"bmi\"\]"
+declare file_content=$( cat "${file}" )
+if [[ " $file_content " =~ $regex ]]
+    then
+        log "best-first-cv OK"
+    else
+        echo "best-first-cv KO:\n $file_content"
+        exit 1
+fi
+# remove the created resources
+run_bigmler delete --from-dir cmd --output-dir cmd_del
+run_bigmler delete --from-dir .build --output-dir cmd_del
+rm -f -R test_inputs.json cmd cmd_del
+rm -f -R .build .bigmler*

--- a/metadata.json
+++ b/metadata.json
@@ -31,5 +31,7 @@
     "quadratically-weighted-kappa",
     "stepwise-regression",
     "batch-explanations"
+    "best-first-cv",
+    "multi-label"
   ]
 }

--- a/multi-label/create-item-models/metadata.json
+++ b/multi-label/create-item-models/metadata.json
@@ -1,0 +1,39 @@
+{
+  "name": "Create item models",
+  "description":
+  "Generate models for a multi-labeled items field",
+  "kind": "script",
+  "source_code": "script.whizzml",
+  "inputs": [
+    {
+      "name": "dataset",
+      "type": "dataset-id",
+      "description": "The data to model"
+    },
+    {
+      "name": "objective",
+      "type": "string",
+      "description":
+      "The objective name or id"
+    },
+    {
+      "name": "model-kind",
+      "type": "string",
+      "default": "model",
+      "description": "The kind of ML model to create: model, ensemble, deepnet or logistic regression"
+    },
+    {
+      "name": "model-parameters",
+      "type": "map",
+      "default": {},
+      "description": "Additional parameters to use when creating models"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "multi-label-models",
+      "type": "map",
+      "description": "A map with items and models, as lists"
+    }
+  ]
+}

--- a/multi-label/create-item-models/readme.md
+++ b/multi-label/create-item-models/readme.md
@@ -1,0 +1,12 @@
+# Creating a model per item
+
+- Provide as input a dataset ID, an items field name, a model kind and
+  the model configuration options.
+- Uses the `items-to-features` script to generate a dataset with one additional
+  binary field per item.
+- Creates a model of the given kind per item by selecting the item field and
+  deselecting the rest of items fields.
+- Returns a map with the list of items and models to be used in predictions.
+
+The lists are returned in a map as the execution's `result`, for later
+convenience, as well as in the output named "result".

--- a/multi-label/create-item-models/script.whizzml
+++ b/multi-label/create-item-models/script.whizzml
@@ -1,0 +1,63 @@
+;; Given a dataset, an items field and a model kind, generates a new
+;; binary field per item and
+;; uses the result to create models of the given kind per item.
+
+;; Find field by either name or id
+(define (find-field* fields field)
+  (or (when (contains? fields field) [(fields field) field])
+      (loop (ids (keys fields))
+        (cond (empty? ids)
+              (raise (str "Field not found: " field))
+              (= field (fields [(head ids) "name"] ""))
+              [(fields (head ids)) (head ids)]
+              (recur (tail ids))))))
+
+;; Given a dataset and a items field id or name, find
+;; the associated list of items and the missing count.
+(define (list-items dataset-id field-id)
+  (let ([f id] (find-field* ((fetch dataset-id) "fields") field-id))
+    (when (not (= "items" (f "optype")))
+      (raise (str "Field '" field-id "' has not the items type")))
+    (let (items (map head (f ["summary" "items"] [])))
+      (when (empty? items)
+        (raise (str "Field '" field-id "' does not contain any item")))
+      [items (f ["summary" "missing_count"] 0) id (f "name")])))
+
+
+;; Given a dataset and an items field, create binary features per item
+
+(define (expand-ds dataset field)
+  (let (script (head (list-scripts {"limit" 1 "name" "Items to features"}))
+        ex-items (create-and-wait-execution
+                   {"script" (script "resource")
+                    "inputs" [["input-dataset" dataset]
+                              ["items-field" field]
+                              ["true-value" "Y"]
+                              ["false-value" "N"]]}))
+    ((fetch ex-items) ["execution" "result"])))
+
+
+;; Adapt parameters to each items objective field
+(define (per-item-conf item items parms objective)
+  (let (other-items (filter (lambda (x) (not (= x item))) items))
+    (merge parms {"objective_field" item
+                  "excluded_fields" (append other-items objective)})))
+
+;; Final workflow for multi-label models generation
+(define (m-l-models dataset objective kind parameters)
+  (let ([items missings id name] (list-items dataset objective)
+        ds-name ((fetch dataset) "name")
+        ext-ds (expand-ds dataset objective)
+        ps (map (lambda (x) (per-item-conf x items parameters objective)) items)
+        ms (map (lambda (p) (create kind ext-ds p)) ps))
+    (wait* ms)
+    {"items" items
+     "objective-id" id
+     "objective-name" name
+     "models" ms
+     "kind" kind}))
+
+(define multi-label-models (m-l-models dataset
+                                       objective
+                                       model-kind
+                                       model-parameters))

--- a/multi-label/metadata.json
+++ b/multi-label/metadata.json
@@ -1,0 +1,9 @@
+{
+  "name": "Multi-label models and predictions",
+  "description": "Scripts library to model data with an items objective field and make predictions using the resulting per-items models",
+  "kind": "package",
+  "components":[
+    "create-item-models",
+    "ml-batch-prediction",
+  ]
+}

--- a/multi-label/ml-batch-prediction/metadata.json
+++ b/multi-label/ml-batch-prediction/metadata.json
@@ -1,0 +1,31 @@
+{
+  "name": "Batch predictions with multi-label models",
+  "description": "Perform a batch prediction using per-item models",
+  "kind": "script",
+  "source_code": "script.whizzml",
+  "inputs": [
+    {
+      "name": "execution",
+      "type": "execution-id",
+      "description": "The execution of `Create item models` that created the per items models needed for making these predictions."
+    },
+    {
+      "name": "dataset",
+      "type": "dataset-id",
+      "description": "A dataset to perform predictions over each of its rows"
+    },
+    {
+      "name": "clean-up?",
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to clean up intermediate resources"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "result",
+      "type": "dataset-id",
+      "description": "The resulting prediction dataset"
+    }
+  ]
+}

--- a/multi-label/ml-batch-prediction/readme.md
+++ b/multi-label/ml-batch-prediction/readme.md
@@ -1,0 +1,7 @@
+# Batch predictions with items models
+
+This script uses the result of
+executing [Create items models](../create-items-models) to
+perform a batch prediction.
+
+See also [the package README](../readme.md).

--- a/multi-label/ml-batch-prediction/script.whizzml
+++ b/multi-label/ml-batch-prediction/script.whizzml
@@ -1,12 +1,3 @@
-;; Find field
-(define (find-field-id fields field)
-  (or (fields field false)
-      (loop (ids (keys fields))
-        (cond (empty? ids) false
-              (= field (fields [(head ids) "name"] "")) (head ids)
-              (recur (tail ids))))))
-
-
 ;; Extracts the result of the given execution, signaling an
 ;; error if it's not of the expected kind.
 (define (exec-result eid)

--- a/multi-label/ml-batch-prediction/script.whizzml
+++ b/multi-label/ml-batch-prediction/script.whizzml
@@ -1,0 +1,57 @@
+;; Find field
+(define (find-field-id fields field)
+  (or (fields field false)
+      (loop (ids (keys fields))
+        (cond (empty? ids) false
+              (= field (fields [(head ids) "name"] "")) (head ids)
+              (recur (tail ids))))))
+
+
+;; Extracts the result of the given execution, signaling an
+;; error if it's not of the expected kind.
+(define (exec-result eid)
+  (let (res ((fetch eid) ["execution" "result"] {}))
+    (when (not (contains? res "items"))
+      (raise (str "Invalid execution: Missing  items in result")))
+    res))
+
+;; Delete resources ignoring errors
+(define (safe-delete id)
+  (try (delete id)
+       (catch e (log-info (str "Error deleting resource " id " ignored")))))
+
+;; Create the chain of batch predictions and datasets accumulating predictions
+(define (bp-datasets batch-predictions datasets models items objective-name)
+  (if (empty? models)
+      [batch-predictions datasets]
+      (let (bp (create-and-wait-batchprediction
+                (head datasets)
+                (head models)
+                {"output_dataset" true
+                "all_fields" true
+                "confidence" true
+                "output_dataset" true
+                "prediction_name" (str objective-name
+                                       ": "
+                                       (head items))})
+            ds ((fetch bp) "output_dataset_resource"))
+       (bp-datasets (cons bp batch-predictions)
+                    (cons ds datasets)
+                    (tail models)
+                    (tail items)
+                    objective-name))))
+
+
+;; Final workflow
+(define (multi-label-predict eid dataset del?)
+  (let (res (exec-result eid)
+        objective-name (res "objective-name")
+        items (res "items")
+        ms (res "models")
+        [bps dss] (bp-datasets [] [dataset] ms items objective-name)
+        ds (head dss))
+     (when del? (map safe-delete bps))
+     (when del? (map safe-delete (tail dss)))
+     ds))
+
+(define result (multi-label-predict execution dataset clean-up?))

--- a/multi-label/ml-batch-prediction/script.whizzml
+++ b/multi-label/ml-batch-prediction/script.whizzml
@@ -42,7 +42,7 @@
         [bps dss] (bp-datasets [] [dataset] ms items objective-name)
         ds (head dss))
      (when del? (map safe-delete bps))
-     (when del? (map safe-delete (tail dss)))
+     (when del? (map safe-delete (tail (butlast dss))))
      ds))
 
 (define result (multi-label-predict execution dataset clean-up?))

--- a/multi-label/readme.md
+++ b/multi-label/readme.md
@@ -1,0 +1,46 @@
+# Multi-label models and predictions
+
+These scripts allow selecting an items field when modeling as objective field
+and predicting with any
+supervised algorithm in BigML. Note that it uses the
+[items-to-features](items-to-features)
+script, so you must previously create it in your account.
+
+With the [create-item-models script](create-item-models),
+given an input dataset and one of its tiems fields, you'll
+generate a collection of predictive models based on the input data.
+The dataset will be extended with a new binary field per item. Each one
+of these fields will be used as objective field in one model in the
+collection while the rest of items fields plus the original objective
+field will be excluded.
+
+To make predictions for new instances using those models, you can use
+accompanying script [ml-batch-prediction](ml-batch-prediction).
+It takes as one of their
+inputs the identifier of the execution that created the models (that
+is, an execution of [create-item-models](create-item-models)),
+and an input dataset to perform a batch prediction using the items models.
+
+## How to install
+
+### Using bigmler
+
+If you have bigmler installed in your system, just checkout this
+repository and, at its top level, issue the commands:
+
+        make compile PKG=items-to-features
+        make compile PKG=multi-label
+
+That will create all three scripts for you.
+
+### Using the web UI
+
+- Install the `items-to-features` script, using
+  [this url](./items-to-features).
+- Install the `create-item-models` script, using
+  [this url](./create-item-models).
+- Install [ml-batch-prediction](./ml-batch-prediction) to be able to create
+  batch predictions given an execution of `create-item-models`.
+
+If necessary, please see [the top-level readme](../readme.md) for more general
+installation instructions.

--- a/multi-label/test/multilabel.csv
+++ b/multi-label/test/multilabel.csv
@@ -1,0 +1,151 @@
+color,year,price,first_name,last_name,sex,class
+Blue,1992,"1208,6988040134",John,Higgins,Male,Worker:Adult
+Blue,2005,"2821,8477368243",Mary,Taylor,Male,Student:Child
+Blue,2010,"1337,9887314402",Bryan,Parker,Male,Student:Child
+Orange,1997,"2367,5836757645",Joseph,Slendenton,Male,Worker:Teenager
+Green,2001,"1929,7757800557",Dylan,Oldman,Male,Worker:Teenager
+Red,2007,"2778,4454948157",Tyler,Bush,Female,Worker:Child
+Red,1997,"1339,331450861",Jacob,Lewis,Male,Student:Teenager
+Green,1990,"1025,3779427037",Sabrina,Bauer,Female,Retired:Adult
+Blue,1998,"1002,265727602",Amy,Whiteman,Female,Worker:Teenager
+Blue,2001,"618,3144850545",Peter,Symons,Male,Worker:Teenager
+Yellow,2013,"1733,6302730143",Adam,Baldwin,Male,Retired:Child
+Blue,2005,"1319,2270314209",Cristina,Yang,Female,Student:Child
+Orange,1996,"492,2495423704",Margareth,Miller,Male,Worker:Teenager
+Green,2003,"2937,036577601",Oleg,Hanson,Female,Retired:Child
+Orange,2010,"2925,2370889187",Martina,Davenport,Male,Pensioner:Child
+Yellow,2008,"1498,6236030124",Ian,Neal,Male,Student:Child
+Red,2003,"905,259514682",Matthew,Garrison,Male,Pensioner:Child
+Blue,2005,"2006,4400569424",Yosufzai,Hamidullah,Male,Student:Child
+Yellow,2001,"2624,6065976918",Cana,Lorik,Female,Pensioner:Teenager
+Green,1992,"1614,7092333883",Bougherra,Madjid,Female,Worker:Adult
+Red,2001,"685,5748016275",Amisone,Liatama,Female,Worker:Teenager
+Red,2005,"729,9721697234",Sonejee,Masand Oscar,Female,Worker:Child
+Red,2009,"2427,1085671969",Girdon,Connor,Male,Pensioner:Child
+Yellow,2013,"461,2222625762",Dublin,George,Male,Student:Child
+Green,2010,"2587,7485279813",Messi,Lionel,Female,Student:Child
+Green,2001,"2488,9446077757",Berezovski,Roman,Female,Worker:Teenager
+Yellow,2000,"2953,9757543132",Baten,Raymond,Female,Worker:Teenager
+Orange,1996,"1304,5304790028",Neill,Lucas,Female,Student:Teenager
+Orange,2010,"1135,3133977279",Fuchs,Christian,Female,Worker:Child
+Blue,2004,"943,2910452485",Sadikhov,Rashad,Female,Student:Child
+Blue,1993,"2691,0514403023",Leslie,St. Fleur,Female,Pensioner:Adult
+Blue,2012,"472,2781032212",Sujon,Md.,Male,Student:Child
+Green,1995,"1823,3408746198",Williams,Rashida,Female,Student:Teenager
+Yellow,1990,"2396,8477286287",Veremko,Siarhei,Male,Pensioner:Adult
+Yellow,1996,"1247,0663902238",Kompany,Vincent,Male,Pensioner:Teenager
+Yellow,2006,"2172,6787462719",Gaynair,Ian,Female,Pensioner:Child
+Blue,2007,"498,9985236786",Nusum,John Barry,Female,Student:Child
+Blue,2003,"1435,728331551",Tshering,Pasang,Female,Pensioner:Child
+Orange,2007,"589,5406030938",Raldes,Ronald,Male,Worker:Child
+Green,1992,"97,6044931337",Emir,Spahic,Female,Pensioner:Adult
+Green,1990,"1202,1776568033",Thuma,Mompati,Female,Student:Adult
+Green,2007,"492,6865650229",Da,Silva Thiago Emiliano,Female,Worker:Child
+Red,2007,"3011,1505417042",Darussalam,Haji Kamis Rosmin,Female,Pensioner:Child
+Green,1996,"2643,3850643113",Popov,Ivelin,Male,Pensioner:Teenager
+Blue,1996,"1309,6954594255",Dagano,Moumouni,Female,Worker:Teenager
+Orange,2003,"564,7560055256",Nahayo,Valery,Female,Worker:Child
+Blue,1991,"1105,0086687207",Sok,Ngon Keo,Female,Student:Adult
+Blue,2010,"2177,9549741075",Eto'o,Fils Samuel,Female,Student:Child
+Yellow,1995,"2534,196062468",Mckenna,Kevin,Male,Pensioner:Teenager
+Red,2002,"692,6152664125",Neves,Fernando,Male,Pensioner:Teenager
+Red,2013,"755,6642088927",Lindo,Ian,Female,Pensioner:Child
+Blue,2007,"182,7708654925",Koulara,Armel,Female,Student:Child
+Red,1994,"1385,5874375329",Zheng,Zhi,Male,Worker:Adult
+Green,2009,"145,7727760896",Yepes,Mario Alberto,Female,Worker:Child
+Green,2006,"606,9931280687",Mroivili,Mahamoud,Male,Worker:Child
+Yellow,1991,"936,3359655142",Andzouana,Kevin,Female,Pensioner:Adult
+Yellow,1997,"2597,7173838653",Mputu,Mabi Trésor,Female,Pensioner:Teenager
+Orange,1992,"523,9688823819",Ruiz,Bryan,Female,Pensioner:Adult
+Green,1997,"2203,8664459139",Srna,Darijo,Female,Student:Teenager
+Green,1993,"696,0307815932",Molina,Odelin,Female,Worker:Adult
+Yellow,2006,"1430,2599276304",Bernardus,Ashar,Male,Pensioner:Child
+Red,2000,"1857,9178862162",Constantinou,Michael,Female,Pensioner:Teenager
+Orange,1991,"1131,3088848144",Rosicky,Tomás,Female,Worker:Adult
+Orange,2012,"216,6008036472",Agger,Daniel,Male,Student:Child
+Blue,2001,"1217,7656148449",Mohamed,Kader Ahmed,Female,Worker:Teenager
+Yellow,1997,"2341,3752764352",Barmettler,Heinz,Male,Worker:Teenager
+Yellow,2005,"2352,2795499191",Ayovi,Walter,Male,Pensioner:Child
+Green,1995,"1679,7641399205",Elhadary,Essam,Female,Worker:Teenager
+Green,2011,"740,1036079861",Portillo,Dagoberto,Male,Student:Child
+Green,1998,"2904,8201544099",Gerrard,Steven,Male,Worker:Teenager
+Blue,1997,"1740,3686330542",Goitom,Daniel,Male,Worker:Teenager
+Yellow,2011,"1905,2812647894",Klavan,Ragnar,Female,Worker:Child
+Blue,1992,"360,5067194328",Debebe,Degu,Male,Pensioner:Adult
+Blue,1990,"1714,5191747584",Benjaminsen,Fróoi,Female,Worker:Adult
+Orange,1994,"1511,6663304977",Moisander,Niklas,Male,Student:Adult
+Green,1999,"1633,2021788582",Lloris,Hugo,Female,Student:Teenager
+Yellow,2004,"2242,2751802839",Pandev,Goran,Female,Pensioner:Child
+Yellow,1995,"2579,6749992184",Kankava,Jaba,Female,Student:Teenager
+Red,1995,"774,1571543626",Lahm,Philipp,Female,Worker:Teenager
+Red,2009,"1739,4712441489",Gyan,Asamoah,Female,Pensioner:Child
+Blue,2008,"235,2902656309",Salpingidis,Dimitrios,Male,Student:Child
+Green,1995,"1492,8213632554",Marshall,Marc,Male,Student:Teenager
+Orange,2002,"1885,2421096414",Cunliffe,Jason,Female,Pensioner:Teenager
+Orange,2013,"1583,8777031638",Ruiz,Gutierrez Carlos Humberto,Male,Worker:Child
+Yellow,1990,"1601,594139345",Zayatte,Kamil,Male,Pensioner:Adult
+Red,1995,"2455,2352377102",Nurse,Chris,Male,Student:Teenager
+Green,1990,"2483,2136700749",Valladares,Noel,Male,Student:Adult
+Red,1997,"1162,3115232103",Chan,Wai Ho,Female,Pensioner:Teenager
+Red,1998,"2942,2041200921",Gera,Zoltán,Female,Student:Teenager
+Yellow,1997,"1650,0801159889",Gunnarsson,Aron Einar,Female,Student:Teenager
+Green,2000,"1821,3423062004",Chhetri,Sunil,Female,Student:Teenager
+Yellow,1991,"1335,4640477225",Buffon,Gianluigi,Male,Student:Adult
+Blue,2008,"470,998002205",Thomas,Shavar,Male,Pensioner:Child
+Green,2002,"2915,6511910148",Hasebe,Makoto,Male,Pensioner:Teenager
+Yellow,2013,"1515,0648513697",Deeb,Amer,Female,Student:Child
+Green,1995,"1651,7636170499",Nurdauletov,Kairat,Female,Worker:Teenager
+Orange,2010,"2220,02646745",Ri,Myong Guk,Female,Student:Child
+Orange,2004,"830,3444026858",Ha,Daesung,Female,Pensioner:Child
+Yellow,2001,"294,5277569704",Al-khaldi,Nawaf,Female,Student:Teenager
+Red,2007,"2923,1300768331",Baimatov,Azamat,Female,Student:Child
+Red,2013,"698,1645570956",Phaphouvaninh,Vixay,Male,Student:Child
+Green,2008,"1997,8963900246",Gorkss,Kaspars,Female,Worker:Child
+Blue,2004,"1791,4113416225",Antar,Roda,Female,Pensioner:Child
+Blue,1991,"1021,6712765284",Gebro,George Duncan,Male,Student:Adult
+Orange,2009,"675,4155647829",Stocklasa,Martin,Female,Pensioner:Child
+Yellow,2009,"266,0776721202",Danilevicius,Tomas,Female,Pensioner:Child
+Red,2000,"2617,8734567836",Peters,René,Male,Worker:Teenager
+Green,1999,"2880,6907464638",Cheng,Ieong Paulo Cheang,Female,Pensioner:Teenager
+Orange,1991,"2808,7526713386",Rajoarimanana,Yvan,Female,Student:Adult
+Red,2006,"355,0306111462",Chavula,Moses,Female,Pensioner:Child
+Yellow,1995,"1583,1619906128",Ashfaq,Ali,Male,Worker:Teenager
+Yellow,2009,"3007,0429383665",Coulibaly,Adama,Female,Student:Child
+Yellow,2011,"1810,8519744016",Mifsud,Michael,Male,Student:Child
+Green,2008,"431,4041002542",Baghayoko,Moussa,Male,Student:Child
+Green,2008,"1553,9206415303",Bell,Colin,Male,Pensioner:Child
+Orange,2012,"375,4461137466",Rodriguez,Pinedo Francisco Javier,Male,Pensioner:Child
+Yellow,2013,"2849,6393379644",Epureanu,Alexandru,Male,Worker:Child
+Blue,2009,"1000,1343116053",Donorov,Lumbengarav,Female,Student:Child
+Orange,1995,"1500,7576369569",Vucinic,Mirko,Male,Worker:Teenager
+Yellow,1997,"2754,8434580565",Mendes,Junior,Male,Worker:Teenager
+Green,1992,"2613,2144275941",Lamyaghri,Nadir,Male,Worker:Adult
+Green,2006,"285,0999431573",Rafael,Joao,Female,Pensioner:Child
+Red,1998,"1053,307505779",Khin,Maung Lwin,Male,Pensioner:Teenager
+Orange,2010,"47,2124297991",Ketjijere,Ronald,Female,Worker:Child
+Blue,1995,"163,7511355691",Sneijder,Wesley,Male,Pensioner:Teenager
+Yellow,1998,"2531,3723585457",Dokunengo,Olivier,Male,Pensioner:Teenager
+Red,1992,"1661,976048246",Nelsen,Ryan,Female,Pensioner:Adult
+Yellow,1991,"2346,777603019",Solorzano,David,Female,Pensioner:Adult
+Green,2012,"324,7167612314",Ouwo,Moussa Maazou,Female,Pensioner:Child
+Orange,2004,"2167,4663536139",Djeparov,Server,Male,Pensioner:Child
+Green,1991,"1820,8444295339",Jean,Robert Yelou,Female,Student:Child
+Orange,2000,"1195,8848717511",Arango,Juan,Female,Pensioner:Adult
+Yellow,1999,"2144,9280432314",Nguyen,Minh Duc,Female,Pensioner:Child
+Green,2012,"1477,4567633756",Ashley,Williams,Male,Worker:Child
+Yellow,2007,"2008,7477736995",Awad,Salim,Female,Pensioner:Adult
+Red,1991,"2132,602162648",Christopher,Katongo,Female,Student:Teenager
+Blue,1990,"1260,8202313893",Matongorere,Nelson,Male,Student:Adult
+Blue,1997,"2315,9830341935",Kargar,Mohammad Yosuf,Male,Student:Child
+Yellow,2009,"745,2523303106",De,Biasi Giovanni,Male,Worker:Teenager
+Orange,1994,"353,961303819",Halilhodzic,Vahid,Female,Student:Teenager
+Green,2010,"2910,935055919",Lalogafuafua,Iofi,Female,Worker:Child
+Blue,1994,"1240,4063031897",Alvarez,De Eulate Jesus Luis,Male,Pensioner:Child
+Yellow,1993,"1643,0100574978",Colin,Girdon,Male,Student:Adult
+Red,1997,"1454,7683959715",Curtis,Thomas,Female,Student:Child
+Blue,2012,"2578,9604741037",Sabella,Alejandro,Male,Worker:Adult
+Yellow,2003,"882,3778326511",Minasyan,Vardan,Female,Worker:Adult
+Yellow,2008,"1932,1543322764",Beeldsnijder,Herbert,Female,Pensioner:Adult
+Green,2010,"2399,3304064386",Osieck,Holger,Female,Student:Child
+Red,1994,"1301,1423041932",Koller,Marcel,Female,Student:Adult
+Orange,2005,"923,9663202204",Vogts,Hans Hubert,Female,Worker:Adult

--- a/multi-label/test/source.json
+++ b/multi-label/test/source.json
@@ -1,0 +1,1 @@
+{"fields": {"000006": {"optype": "items", "item_analysis": {"separator": ":"}}}}

--- a/multi-label/test/test.sh
+++ b/multi-label/test/test.sh
@@ -60,12 +60,13 @@ if [[ " $file_content " =~ $regex ]]
         exit 1
 fi
 # remove the created resources
+run_bigmler delete --from-dir cmd/pre_test --output-dir cmd_del
+run_bigmler delete --from-dir .build1 --output-dir cmd_del
+run_bigmler delete --from-dir .build2 --output-dir cmd_del
+run_bigmler delete --from-dir .build3 --output-dir cmd_del
 cat cmd/results/execution | while read execution
 do
 run_bigmler delete --id "$execution" --output-dir cmd_del
 done
-run_bigmler delete --from-dir .build1 --output-dir cmd_del
-run_bigmler delete --from-dir .build2 --output-dir cmd_del
-run_bigmler delete --from-dir .build3 --output-dir cmd_del
 rm -f -R test_inputs.json cmd cmd_del
 rm -f -R .build* .bigmler*

--- a/multi-label/test/test.sh
+++ b/multi-label/test/test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+source ../../test-utils.sh
+
+rm -f -R cmd_del
+rm -f -R cmd
+rm -f -R .build1
+rm -f -R .build2
+rm -f -R .build3
+
+log "-------------------------------------------------------"
+log "Test for multi-label script"
+run_bigmler whizzml --package-dir ../../items-to-features --output-dir ./.build1
+run_bigmler whizzml --package-dir ../create-item-models \
+                    --output-dir ./.build2
+run_bigmler whizzml --package-dir ../ml-batch-prediction \
+                    --output-dir ./.build3
+
+# creating the resources needed to run the test
+run_bigmler --train ./multilabel.csv --no-model \
+            --source-attributes source.json \
+            --project "Whizzml examples tests" --output-dir cmd/pre_test
+# building the inputs for the test
+prefix='[["dataset", "'
+suffix='"], ["objective", "class"], ["model-kind" ,"model"], ["model-parameters", {}]]'
+text=''
+cat cmd/pre_test/dataset | while read datasets
+do
+echo "$prefix$datasets$suffix" > "test_inputs.json"
+done
+log "Testing multi-label script -------------------------------"
+# running the execution to create models with the given inputs
+run_bigmler execute --scripts .build2/create-item-models/scripts \
+                    --inputs test_inputs.json \
+                    --output-dir cmd/results --verbosity 1
+prefix='[["execution", "'
+suffix='"], ["dataset", "'
+suffix2='"], ["clean-up?" , true]]'
+text=''
+cat cmd/results/execution | while read execution
+do
+cat cmd/pre_test/dataset | while read datasets
+do
+echo "$prefix$execution$suffix$datasets$suffix2" > "test_inputs.json"
+done
+done
+# running the execution to create models with the given inputs
+run_bigmler execute --scripts .build3/ml-batch-prediction/scripts \
+                    --inputs test_inputs.json \
+                    --output-dir cmd/results --verbosity 1
+# check the outputs
+declare file="cmd/results/whizzml_results.json"
+declare regex="\"outputs\": \[\[\"result\", \"dataset\/"
+declare file_content=$( cat "${file}" )
+if [[ " $file_content " =~ $regex ]]
+    then
+        log "multi-label OK"
+    else
+        echo "multi-label KO:\n $file_content"
+        exit 1
+fi
+# remove the created resources
+cat cmd/results/execution | while read execution
+do
+run_bigmler delete --id "$execution" --output-dir cmd_del
+done
+run_bigmler delete --from-dir .build1 --output-dir cmd_del
+run_bigmler delete --from-dir .build2 --output-dir cmd_del
+run_bigmler delete --from-dir .build3 --output-dir cmd_del
+rm -f -R test_inputs.json cmd cmd_del
+rm -f -R .build* .bigmler*

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,11 @@ By convention, when the artifact is a library, the files are called
   (levels).
 - `batch-explanations` A simple way to perform many predictions with
   explanations
+- `best-first-cv` Extends the `best-first` code to find the list of
+  fields in your dataset that produce the best models. Allows iteration and
+  uses cross-validation.
+- `multi-label` Classification for datasets with a
+   multi-label (items) objective field.
 
 ## How to install
 


### PR DESCRIPTION
A new best-first-cv script based on best-first has been added to:
- use cross-validation
- allow other model types to be used
- allow a list of pre-selected fields to be used

the last point allows to iteratively call the script to improve the results. Also, results add the evaluation metric for every new field subset chosen in the process.

The muiti-label scripts need the existing `items-to-features` script and create models for every item and their predictions.