### PR TITLE
New configuration parameters

### DIFF
--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -97,6 +97,15 @@
                 " the training execution) or provide a training dataset to start"
                 " training again with the new excluded_fields"))))
 
+;; Checks if excluded-models are valid unsupervised models
+(define (check-excluded-models excluded-models)
+  (let (all-models #["cluster" "anomaly" "association" "pca" "topicmodel"]
+        bads (difference (set* excluded-models) all-models))
+    (when (not (empty? bads))
+      (log-warn "WARNING: The following unsupervised models from "
+                "excluded-models are not valid: "
+                (str (list* bads))))))
+
 ;; Checks if train validation and test datasets contain the same fields
 (define (check-datasets-fields train valid test)
   (let (fields-set (lambda (ds)
@@ -121,6 +130,12 @@
 ;;;;;;;;;;;;; Creation of unsupervised models ;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; Whether the model "type" should be created based on the
+;; list of excluded models
+(define (create-unsupervised? type excluded-models)
+  (when (string? type)
+    (not (member? type (or excluded-models [])))))
+
 (define (_set-unsupervised-params dataset params exclude)
   (let (name (str (resource-name dataset) " | unsupervised-gen")
         params (assoc (or params {}) "name" name)
@@ -131,10 +146,11 @@
       params)))
 
 ;; Creates an unsupervised model (specified by type) from a given
-;; dataset and some params. exclude is a flag to exclude
-;; objective id for the model creation
-(define (create-unsupervised type dataset params exclude)
-  (let (final-params (_set-unsupervised-params dataset params exclude))
+;; dataset and some params. Objective field is excluded from all
+;; models but associations
+(define (create-unsupervised type dataset params)
+  (let (exclude (not (= type "association"))
+        final-params (_set-unsupervised-params dataset params exclude))
     (try
      (log-info " - Creating " type)
      (create type dataset final-params)

--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -83,25 +83,23 @@
     (raise (str "If you don't define a correct train-dataset,"
                 "you must define a correct previous execution"))))
 
-;; Checks if the values of the configuration inputs from
-;; the given automl-execution are different from the ones
-;; given by the user in the current execution
-;; If so, values from automl-execution will be used
-(define (check-config-input new-input prev-input name)
-  (when (not (= new-input prev-input))
-    (log-warn (str name " input is overwritten by the one from the "
-                   "previous execution with value "
-                   prev-input))))
-
+;; Checks that all the needed params are in the configuration
+(define (check-configuration-params config)
+  (let (correct #["excluded-fields" "excluded-models"
+                  "pca-variance-threshold" "leverage-threshold"]
+        dif (difference correct (set* (keys (or config {})))))
+    (when (not (empty? dif))
+      (raise (str "Can't find the following parameters in the "
+                  "configuration-params: " dif)))))
 
 ;; Checks if excluded-models are valid unsupervised models
 (define (check-excluded-models excluded-models)
   (let (all-models #["cluster" "anomaly" "association" "pca" "topicmodel"]
         bads (difference (set* excluded-models) all-models))
     (when (not (empty? bads))
-      (log-warn "WARNING: The following unsupervised models from "
-                "excluded-models are not valid: "
-                (str (list* bads))))))
+      (log-warn (str "WARNING: The following unsupervised models from "
+                     "excluded-models are not valid: "
+                     (list* bads))))))
 
 ;; Checks if train validation and test datasets contain the same fields
 (define (check-datasets-fields train valid test)
@@ -122,7 +120,6 @@
                 " and not in your validation or test datasets (besides the"
                 " objective field)"))))
 
-
 (define (_check-number value min-value max-value name)
   (when (or (not (number? value))
             (not (<= min-value value max-value)))
@@ -130,8 +127,7 @@
                 " must be a positive number "
                 " in the interval [" min-value  ","  max-value  "]"))))
 
-
-;; Checks the rest of params
+;; Checks params values
 (define (check-params pca-variance-threshold leverage-threshold)
   (_check-number pca-variance-threshold 0 1 "pca-variance-threshold")
   (_check-number leverage-threshold 0 1 "leverage-threshold"))
@@ -476,9 +472,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (_filter-dataset-fields dataset excluded-fields)
-  (let (fields (resource-fields dataset))
+  (let (fields (resource-fields dataset)
+        excluded (or excluded-fields []))
     (field-names-from-ids
-     (filter (lambda (f) (not (member? ((fields f) "name") excluded-fields)))
+     (filter (lambda (f) (not (member? ((fields f) "name") excluded)))
              (keys fields))
      dataset)))
 

--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -1,5 +1,5 @@
 ;;;;;;;;;;;;;;;;;;;;;;; AUTOML LIBRARY ;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;; library version 0.1 ;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;; library version 0.2 ;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;; Private functions start with _ ;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;; Check automl script ;;;;;;;;;;;;;;;;;;;;;
 
@@ -83,19 +83,19 @@
     (raise (str "If you don't define a correct train-dataset,"
                 "you must define a correct previous execution"))))
 
-;; Checks excluded fields. We can't reuse resources from
-;; previous executions if the excluded_fields were different.
-(define (check-excluded-fields train exec excluded)
-  (if (and (not (= (resource-type train) "dataset"))
-           (= (resource-type exec) "execution")
-           (not (empty? excluded))
-           (not (= excluded (input-from-exec exec "excluded_fields"))))
-    (raise (str "Your excluded_fields are different to the ones you provided"
-                " in the given previous execution of automl."
-                " Please, provide the same excluded_fields (or leave blank the"
-                " excluded_fields input to use the same excluded_fields as in"
-                " the training execution) or provide a training dataset to start"
-                " training again with the new excluded_fields"))))
+;; Checks if the values of the configuration inputs from
+;; the given automl-execution are different from the ones
+;; given by the user in the current execution
+;; If so, values from automl-execution will be used
+(define (check-config-input new-input prev-input name)
+  (log-info new-input)
+  (log-info prev-input)
+  (log-info name)
+  (when (not (= new-input prev-input))
+    (log-warn (str name " input is overwritten by the one from the "
+                   "previous execution with value "
+                   prev-input))))
+
 
 ;; Checks if excluded-models are valid unsupervised models
 (define (check-excluded-models excluded-models)

--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -130,7 +130,7 @@
 ;; Checks params values
 (define (check-params pca-variance-threshold max-rules)
   (_check-in-range pca-variance-threshold 0 1 "pca-variance-threshold")
-  (_check-in-range max-rules 0 1000 "max-rules"))
+  (_check-in-range  (floor max-rules) 0 1000 "max-rules"))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -88,9 +88,6 @@
 ;; given by the user in the current execution
 ;; If so, values from automl-execution will be used
 (define (check-config-input new-input prev-input name)
-  (log-info new-input)
-  (log-info prev-input)
-  (log-info name)
   (when (not (= new-input prev-input))
     (log-warn (str name " input is overwritten by the one from the "
                    "previous execution with value "

--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -86,7 +86,7 @@
 ;; Checks that all the needed params are in the configuration
 (define (check-configuration-params config)
   (let (correct #["excluded-fields" "excluded-models"
-                  "pca-variance-threshold" "leverage-threshold"]
+                  "pca-variance-threshold" "max-rules"]
         dif (difference correct (set* (keys (or config {})))))
     (when (not (empty? dif))
       (raise (str "Can't find the following parameters in the "
@@ -120,17 +120,17 @@
                 " and not in your validation or test datasets (besides the"
                 " objective field)"))))
 
-(define (_check-number value min-value max-value name)
+(define (_check-in-range value min-value max-value name)
   (when (or (not (number? value))
             (not (<= min-value value max-value)))
     (raise (str name
-                " must be a positive number "
+                " must be a number "
                 " in the interval [" min-value  ","  max-value  "]"))))
 
 ;; Checks params values
-(define (check-params pca-variance-threshold leverage-threshold)
-  (_check-number pca-variance-threshold 0 1 "pca-variance-threshold")
-  (_check-number leverage-threshold 0 1 "leverage-threshold"))
+(define (check-params pca-variance-threshold max-rules)
+  (_check-in-range pca-variance-threshold 0 1 "pca-variance-threshold")
+  (_check-in-range max-rules 0 1000 "max-rules"))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -257,7 +257,7 @@
         total (+ (count lhs) (count rhs)))
     (= total (count (field-names-from-ids (concat lhs rhs) dataset-id)))))
 
-(define (_flatline-rule association rule match dataset-id threshold)
+(define (_flatline-rule association rule match dataset-id)
   (when (_check-assoc-field-exists association rule dataset-id)
     (let (fields (resource-fields association)
           associations (association "associations" {})
@@ -266,34 +266,30 @@
           (lambda (i) (_flatline-item (items i) (fields ((items i) "field_id"))))
           lhs (map get-item-fn (rule "lhs"))
           rhs (map get-item-fn (rule "rhs"))
-          metric (rule "leverage" 1)
           lhs (if (> (count lhs) 1)
                 (str "(and " (join " " lhs) ")")
                 (join " " lhs))
           rhs (if (> (count rhs) 1)
                 (str "(and " (join " " rhs) ")")
                 (join " " rhs)))
-      (when (>= (abs metric) threshold)
-        (cond (= match "antecedent")
-              lhs
-              (= match "consequent")
-              rhs
-              (str "(and " lhs " " rhs ")"))))))
+      (cond (= match "antecedent")
+            lhs
+            (= match "consequent")
+            rhs
+            (str "(and " lhs " " rhs ")")))))
 
-(define (_batch-association-sets dataset-id association-id match threshold)
+(define (_batch-association-sets dataset-id association-id match max-rules)
   (let (association (fetch association-id)
         associations (association "associations" {})
         rules (associations "rules" [])
-        rule-ids (map (lambda (r) (r "id")) rules)
-        rules (filter (lambda (r) (member? (r "id") rule-ids))
-                      rules)
-        flatline-rules (map (lambda (rule)
-                              (_flatline-rule association
-                                              rule
-                                              match
-                                              dataset-id
-                                              threshold))
-                            rules)
+        flatline-rules (take max-rules
+                             (map (lambda (rule)
+                                    (_flatline-rule association
+                                                    rule
+                                                    match
+                                                    dataset-id))
+                                  rules))
+
         new-fields (iterate (acc [] flatline-rule flatline-rules rule rules)
                      (if flatline-rule
                        (append acc {"field" flatline-rule
@@ -349,12 +345,13 @@
 
 ;; Adds to the dataset a new set of fields coming from batch
 ;; association sets from association discovery models in model-list
-;; User can also set a list of fields to be excluded and a threshold
-;; value for the association metric value
-(define (assoc-feature-gen dataset-id model-list name excluded th)
-  (let (new-fields
-        (map (lambda(m) (_batch-association-sets dataset-id m "antecedent" th))
-             (_model-from-list model-list "association")))
+;; User can also set a list of fields to be excluded and a maximum
+;; number of rules that should be obtained
+(define (assoc-feature-gen dataset-id model-list name excluded num-of-rules)
+  (let (rules (floor (/ num-of-rules 2))
+        new-fields
+        (map (lambda(m) (_batch-association-sets dataset-id m "antecedent" rules))
+                        (_model-from-list model-list "association")))
     (_dataset-with-rules dataset-id name (_flatten new-fields) excluded)))
 
 ;; From a batch score, obtains the generated output dataset

--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -123,14 +123,22 @@
                  (> (count (difference train-fields test-fields)) 1)))
       (log-warn "WARNING: There are some fields that are in your train dataset"
                 " and not in your validation or test datasets (besides the"
-                " objective field"))))
+                " objective field)"))))
+
+
+(define (_check-number value min-value max-value name)
+  (when (or (not (number? value))
+            (not (<= min-value value max-value)))
+    (raise (str name
+                " must be a positive number "
+                " in the interval [" min-value  ","  max-value  "]"))))
+
 
 ;; Checks the rest of params
-(define (check-params pca-variance-threshold)
-  (if (or (not (number? pca-variance-threshold))
-          (not (<= 0 pca-variance-threshold 1)))
-    (raise (str "pca-variance-threshold must be a positive number "
-                "in the interval [0,1]"))))
+(define (check-params pca-variance-threshold leverage-threshold)
+  (_check-number pca-variance-threshold 0 1 "pca-variance-threshold")
+  (_check-number leverage-threshold 0 1 "leverage-threshold"))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;; UNSUPERVISED  GENERATION ;;;;;;;;;;;;;;;;;;;;
@@ -256,7 +264,7 @@
         total (+ (count lhs) (count rhs)))
     (= total (count (field-names-from-ids (concat lhs rhs) dataset-id)))))
 
-(define (_flatline-rule association rule match dataset-id)
+(define (_flatline-rule association rule match dataset-id threshold)
   (when (_check-assoc-field-exists association rule dataset-id)
     (let (fields (resource-fields association)
           associations (association "associations" {})
@@ -265,29 +273,33 @@
           (lambda (i) (_flatline-item (items i) (fields ((items i) "field_id"))))
           lhs (map get-item-fn (rule "lhs"))
           rhs (map get-item-fn (rule "rhs"))
+          metric (rule "leverage" 1)
           lhs (if (> (count lhs) 1)
                 (str "(and " (join " " lhs) ")")
                 (join " " lhs))
           rhs (if (> (count rhs) 1)
                 (str "(and " (join " " rhs) ")")
                 (join " " rhs)))
-      (cond (= match "antecedent")
-            lhs
-            (= match "consequent")
-            rhs
-            (str "(and " lhs " " rhs ")")))))
+      (when (>= (abs metric) threshold)
+        (cond (= match "antecedent")
+              lhs
+              (= match "consequent")
+              rhs
+              (str "(and " lhs " " rhs ")"))))))
 
-(define (_batch-association-sets dataset-id association-id  match . rule-ids)
+(define (_batch-association-sets dataset-id association-id match threshold)
   (let (association (fetch association-id)
         associations (association "associations" {})
         rules (associations "rules" [])
-        rule-ids (if (empty? (head rule-ids []))
-                   (map (lambda (r) (r "id")) rules)
-                   (head rule-ids))
+        rule-ids (map (lambda (r) (r "id")) rules)
         rules (filter (lambda (r) (member? (r "id") rule-ids))
                       rules)
-        flatline-rules (map (lambda (r)
-                              (_flatline-rule association r match dataset-id))
+        flatline-rules (map (lambda (rule)
+                              (_flatline-rule association
+                                              rule
+                                              match
+                                              dataset-id
+                                              threshold))
                             rules)
         new-fields (iterate (acc [] flatline-rule flatline-rules rule rules)
                      (if flatline-rule
@@ -344,9 +356,11 @@
 
 ;; Adds to the dataset a new set of fields coming from batch
 ;; association sets from association discovery models in model-list
-(define (assoc-feature-gen dataset-id model-list name excluded)
+;; User can also set a list of fields to be excluded and a threshold
+;; value for the association metric value
+(define (assoc-feature-gen dataset-id model-list name excluded th)
   (let (new-fields
-        (map (lambda(m) (_batch-association-sets dataset-id m "antecedent"))
+        (map (lambda(m) (_batch-association-sets dataset-id m "antecedent" th))
              (_model-from-list model-list "association")))
     (_dataset-with-rules dataset-id name (_flatten new-fields) excluded)))
 

--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -125,6 +125,13 @@
                 " and not in your validation or test datasets (besides the"
                 " objective field"))))
 
+;; Checks the rest of params
+(define (check-params pca-variance-threshold)
+  (if (or (not (number? pca-variance-threshold))
+          (not (<= 0 pca-variance-threshold 1)))
+    (raise (str "pca-variance-threshold must be a positive number "
+                "in the interval [0,1]"))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;; UNSUPERVISED  GENERATION ;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;; Creation of unsupervised models ;;;;;;;;;;;;;;;;;
@@ -320,18 +327,20 @@
 ;;;;;;;;;;;;; Extend datasets generating new features;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (_unsupervised-batch dataset-id model-id name batch-type)
-  (let (params {"name" (str name " | " batch-type) "output_dataset" true})
+(define (_unsupervised-batch dataset-id model-id name batch-type params)
+  (let (params (merge (or params {})
+                      {"name" (str name " | " batch-type)
+                       "output_dataset" true}))
     (try
      (create batch-type dataset-id  model-id params)
      (catch e
        (log-warn "   WARNING: Could not create the " batch-type)))))
 
 ;; Creates a batch scoring from a dataset and an unsupervised model
-(define (unsupervised-feature-gen dataset-id model-list name m-type b-type)
+(define (unsupervised-feature-gen dataset-id model-list name m-type b-type params)
   (let (models (_model-from-list model-list m-type))
     (when (not (empty? models))
-      (_unsupervised-batch dataset-id (head models) name b-type))))
+      (_unsupervised-batch dataset-id (head models) name b-type params))))
 
 ;; Adds to the dataset a new set of fields coming from batch
 ;; association sets from association discovery models in model-list

--- a/automl/automl-script/metadata.json
+++ b/automl/automl-script/metadata.json
@@ -31,28 +31,13 @@
       "description": "Previous execution of this script, to reuse created resources, e.g. execution/5d272205eba31d61920005cd"
     },
     {
-      "name": "excluded-fields",
-      "type": "list",
-      "default": [],
-      "description": "List of field names to be excluded from all the datasets. Overwritten if automl-execution is given. Empty by default"
-    },
-    {
-      "name": "excluded-models",
-      "type": "list",
-      "default": [],
-      "description": "List of unsupervised models that won't be created during feature generation, e.g. ['association', 'pca']. Overwritten if automl-execution is given. Empty by default"
-    },
-    {
-      "name": "pca-variance-threshold",
-      "type": "number",
-      "default": 1,
-      "description": "The PCA projection uses the minimum number of components such that the cumulative explained variance is greater than the given threshold. Values from 0 to 1. Overwritten if automl-execution is given. All the components will be used by default "
-    },
-    {
-      "name": "leverage-threshold",
-      "type": "number",
-      "default": 0,
-      "description": "Associations with an absolute leverage value lower than the threshold will be ignored. Values from 0 to 1. Overwritten if automl-execution is given. Default value is 0 (all the associations will be included in the extended dataset)"
+      "name": "configuration-params",
+      "type": "map",
+      "default": {"excluded-fields": [],
+                  "excluded-models": [],
+                  "pca-variance-threshold": 1,
+                  "leverage-threshold": 0},
+      "description": "Execution configuration parameters. They will be overwritten if automl-execution is given. See README for more information"
     }
   ],
   "outputs":[

--- a/automl/automl-script/metadata.json
+++ b/automl/automl-script/metadata.json
@@ -48,7 +48,7 @@
       "default": 1,
       "description": "The PCA projection uses the minimum number of components such that the cumulative explained variance is greater than the given threshold. Values from 0 to 1. Overwritten if automl-execution is given. All the components will be used by default "
     },
-bsc    {
+    {
       "name": "leverage-threshold",
       "type": "number",
       "default": 0,

--- a/automl/automl-script/metadata.json
+++ b/automl/automl-script/metadata.json
@@ -36,7 +36,7 @@
       "default": {"excluded-fields": [],
                   "excluded-models": [],
                   "pca-variance-threshold": 1,
-                  "leverage-threshold": 0},
+                  "max-rules": 20},
       "description": "Execution configuration parameters. They will be overwritten if automl-execution is given. See README for more information"
     }
   ],

--- a/automl/automl-script/metadata.json
+++ b/automl/automl-script/metadata.json
@@ -34,25 +34,25 @@
       "name": "excluded-fields",
       "type": "list",
       "default": [],
-      "description": "List of field names to be excluded from all the datasets. Empty by default"
+      "description": "List of field names to be excluded from all the datasets. Overwritten if automl-execution is given. Empty by default"
     },
     {
       "name": "excluded-models",
       "type": "list",
       "default": [],
-      "description": "List of unsupervised models that won't be created nor reused during feature generation, e.g. ['association', 'pca']. Empty by default"
+      "description": "List of unsupervised models that won't be created during feature generation, e.g. ['association', 'pca']. Overwritten if automl-execution is given. Empty by default"
     },
     {
       "name": "pca-variance-threshold",
       "type": "number",
       "default": 1,
-      "description": "The PCA projection uses the minimum number of components such that the cumulative explained variance is greater than the given threshold. Values from 0 to 1. All the components will be used by default "
+      "description": "The PCA projection uses the minimum number of components such that the cumulative explained variance is greater than the given threshold. Values from 0 to 1. Overwritten if automl-execution is given. All the components will be used by default "
     },
-    {
+bsc    {
       "name": "leverage-threshold",
       "type": "number",
       "default": 0,
-      "description": "Associations with a leverage (absolute value) lower than the threshold will be ignored. Values from 0 to 1. Default value is 0 (all the associations will be included in the extended dataset)"
+      "description": "Associations with an absolute leverage value lower than the threshold will be ignored. Values from 0 to 1. Overwritten if automl-execution is given. Default value is 0 (all the associations will be included in the extended dataset)"
     }
   ],
   "outputs":[
@@ -66,7 +66,6 @@
       "type": "evaluation-id",
       "description": "Evaluation of the fusion model with the validation dataset"
     },
-
     {
       "name": "output-fusion",
       "type": "fusion-id",

--- a/automl/automl-script/metadata.json
+++ b/automl/automl-script/metadata.json
@@ -35,6 +35,12 @@
       "type": "list",
       "default": [],
       "description": "List of field names to be excluded from all the datasets. Empty by default"
+    },
+    {
+      "name": "excluded-models",
+      "type": "list",
+      "default": [],
+      "description": "List of unsupervised models that won't be created nor reused during feature generation, e.g. ['association', 'pca']. Empty by default"
     }
   ],
   "outputs":[

--- a/automl/automl-script/metadata.json
+++ b/automl/automl-script/metadata.json
@@ -41,6 +41,12 @@
       "type": "list",
       "default": [],
       "description": "List of unsupervised models that won't be created nor reused during feature generation, e.g. ['association', 'pca']. Empty by default"
+    },
+    {
+      "name": "pca-variance-threshold",
+      "type": "number",
+      "default": 1,
+      "description": "The PCA projection uses the minimum number of components such that the cumulative explained variance is greater than the given threshold. Values from 0 to 1. All the components will be used by default "
     }
   ],
   "outputs":[

--- a/automl/automl-script/metadata.json
+++ b/automl/automl-script/metadata.json
@@ -47,6 +47,12 @@
       "type": "number",
       "default": 1,
       "description": "The PCA projection uses the minimum number of components such that the cumulative explained variance is greater than the given threshold. Values from 0 to 1. All the components will be used by default "
+    },
+    {
+      "name": "leverage-threshold",
+      "type": "number",
+      "default": 0,
+      "description": "Associations with a leverage (absolute value) lower than the threshold will be ignored. Values from 0 to 1. Default value is 0 (all the associations will be included in the extended dataset)"
     }
   ],
   "outputs":[

--- a/automl/automl-script/readme.md
+++ b/automl/automl-script/readme.md
@@ -42,29 +42,29 @@ The **inputs** for the script are:
   `automl-execution` should be provided for the script to work. When
   both are provided, the `automl-execution` argument is discarded and
   new resources are generated from the training data.
-* `excluded-fields`: (list) List of fields that will be excluded from
-  any dataset before any other process starts. e.g. ["bmi",
-  "age"]. Overwritten if automl-execution is given. Empty by default.
-* `excluded-models`: (list) List of unsupervised models that won't be
-  created nor reused during feature generation. e.g. ["anomaly",
+* `configuration-params`: (map) Execution configuration
+  parameters. They will be overwritten if automl-execution is
+  given. Overwritten if automl-execution is given. The following
+  values must be provided:
+  * `excluded-fields`: (list) List of fields that will be excluded
+  from any dataset before any other process starts. e.g. ["bmi",
+  "age"]. Empty by default.
+  * `excluded-models`: (list) List of unsupervised models that won't
+  be created nor reused during feature generation. e.g. ["anomaly",
   "cluster"]. Possible values are: association, cluster, anomaly, pca
-  or topicmodel. Overwritten if automl-execution is given.  Empty by
-  default
-* `pca-variance-threshold`: (number) The PCA projection uses the
+  or topicmodel. Empty by default
+  * `pca-variance-threshold`: (number) The PCA projection uses the
   minimum number of components such that the cumulative explained
-  variance is greater than the given threshold. Values from 0
-  to 1. Overwritten if automl-execution is given. Default value is 1
-  (all the components will be used)
-* `leverage-threshold`: (number) Associations with an absolute
-  leverage lower than the threshold will be ignored. Overwritten if
-  automl-execution is given. Default value is 0 (all the association
-  will be added to the extended dataset)
+  variance is greater than the given threshold. Values from 0 to 1.
+  Default value is 1 (all the components will be used)
+  * `leverage-threshold`: (number) Associations with an absolute
+  leverage lower than the threshold will be ignored.  Default value is
+  0 (all the association will be added to the extended dataset)
 
 
-**WARNING** All the configuration inputs (`excluded-fields`,
-`excluded-models`, `pca-variance-threshold`, `leverage-threshold`) are
-overwritten by the corresponding input in `automl-execution` if this
-is given.
+**WARNING** Remember that, to avoid confusion, `configuration-params`
+are overwritten by the corresponding input in `automl-execution` if
+this is given.
 
 The **outputs** for the script are:
 * `output-dataset`: (dataset-id) Dataset with final predictions for the test dataset

--- a/automl/automl-script/readme.md
+++ b/automl/automl-script/readme.md
@@ -10,7 +10,7 @@ automatically done:
 
 -  `Unsupervised Models Generation`: Creating the following
   **unsupervised models**: `Cluster`, `Anomaly Detector`, `Association
-  Discovery` (with lift and leverage as search_strategies), `PCA` and
+  Discovery` (with leverage and lift as search_strategy), `PCA` and
   `Topic Model` (for datasets that contain text fields).
 -  `Feature Generation`: Using the unsupervised models created
   previously to append automatically generated new features to all the
@@ -53,8 +53,10 @@ The **inputs** for the script are:
   minimum number of components such that the cumulative explained
   variance is greater than the given threshold. Values from 0
   to 1. Default value is 1 (all the components will be used)
-
-
+* `leverage-threshold`: (number) Associations with a leverage
+  (absolute value) lower than the threshold will be ignored. Default
+  value is 0 (all the association will be added to the extended
+  dataset)
 
 The **outputs** for the script are:
 * `output-dataset`: (dataset-id) Dataset with final predictions for the test dataset

--- a/automl/automl-script/readme.md
+++ b/automl/automl-script/readme.md
@@ -44,19 +44,27 @@ The **inputs** for the script are:
   new resources are generated from the training data.
 * `excluded-fields`: (list) List of fields that will be excluded from
   any dataset before any other process starts. e.g. ["bmi",
-  "age"]. Empty by default
+  "age"]. Overwritten if automl-execution is given. Empty by default.
 * `excluded-models`: (list) List of unsupervised models that won't be
   created nor reused during feature generation. e.g. ["anomaly",
   "cluster"]. Possible values are: association, cluster, anomaly, pca
-  or topicmodel. Empty by default
+  or topicmodel. Overwritten if automl-execution is given.  Empty by
+  default
 * `pca-variance-threshold`: (number) The PCA projection uses the
   minimum number of components such that the cumulative explained
   variance is greater than the given threshold. Values from 0
-  to 1. Default value is 1 (all the components will be used)
-* `leverage-threshold`: (number) Associations with a leverage
-  (absolute value) lower than the threshold will be ignored. Default
-  value is 0 (all the association will be added to the extended
-  dataset)
+  to 1. Overwritten if automl-execution is given. Default value is 1
+  (all the components will be used)
+* `leverage-threshold`: (number) Associations with an absolute
+  leverage lower than the threshold will be ignored. Overwritten if
+  automl-execution is given. Default value is 0 (all the association
+  will be added to the extended dataset)
+
+
+**WARNING** All the configuration inputs (`excluded-fields`,
+`excluded-models`, `pca-variance-threshold`, `leverage-threshold`) are
+overwritten by the corresponding input in `automl-execution` if this
+is given.
 
 The **outputs** for the script are:
 * `output-dataset`: (dataset-id) Dataset with final predictions for the test dataset

--- a/automl/automl-script/readme.md
+++ b/automl/automl-script/readme.md
@@ -45,6 +45,10 @@ The **inputs** for the script are:
 * `excluded-fields`: (list) List of fields that will be excluded from
   any dataset before any other process starts. e.g. ["bmi",
   "age"]. Empty by default
+* `excluded-models`: (list) List of unsupervised models that won't be
+  created nor reused during feature generation. e.g. ["anomaly",
+  "cluster"]. Possible values are: association, cluster, anomaly, pca
+  or topicmodel. Empty by default
 
 The **outputs** for the script are:
 * `output-dataset`: (dataset-id) Dataset with final predictions for the test dataset

--- a/automl/automl-script/readme.md
+++ b/automl/automl-script/readme.md
@@ -56,7 +56,7 @@ The **inputs** for the script are:
   minimum number of components such that the cumulative explained
   variance is greater than the given threshold. Values from 0 to 1.
   Default value is 1 (all the components will be used)
-  * `max-rules`: (number) Maximum number of association rules
+  * `max-rules`: (integer) Maximum number of association rules
     that should be included in the extended datasets. Default value
     is 20. The final number of rules added to the dataset can be lower
     than this value if there aren't enough rules in the created

--- a/automl/automl-script/readme.md
+++ b/automl/automl-script/readme.md
@@ -49,6 +49,12 @@ The **inputs** for the script are:
   created nor reused during feature generation. e.g. ["anomaly",
   "cluster"]. Possible values are: association, cluster, anomaly, pca
   or topicmodel. Empty by default
+* `pca-variance-threshold`: (number) The PCA projection uses the
+  minimum number of components such that the cumulative explained
+  variance is greater than the given threshold. Values from 0
+  to 1. Default value is 1 (all the components will be used)
+
+
 
 The **outputs** for the script are:
 * `output-dataset`: (dataset-id) Dataset with final predictions for the test dataset

--- a/automl/automl-script/readme.md
+++ b/automl/automl-script/readme.md
@@ -44,8 +44,7 @@ The **inputs** for the script are:
   new resources are generated from the training data.
 * `configuration-params`: (map) Execution configuration
   parameters. They will be overwritten if automl-execution is
-  given. Overwritten if automl-execution is given. The following
-  values must be provided:
+  given. The following values must be provided:
   * `excluded-fields`: (list) List of fields that will be excluded
   from any dataset before any other process starts. e.g. ["bmi",
   "age"]. Empty by default.
@@ -57,10 +56,12 @@ The **inputs** for the script are:
   minimum number of components such that the cumulative explained
   variance is greater than the given threshold. Values from 0 to 1.
   Default value is 1 (all the components will be used)
-  * `leverage-threshold`: (number) Associations with an absolute
-  leverage lower than the threshold will be ignored.  Default value is
-  0 (all the association will be added to the extended dataset)
-
+  * `max-rules`: (number) Maximum number of association rules
+    that should be included in the extended datasets. Default value
+    is 20. The final number of rules added to the dataset can be lower
+    than this value if there aren't enough rules in the created
+    association discovery models or if the same rules appear on more
+    than one association discovery model.
 
 **WARNING** Remember that, to avoid confusion, `configuration-params`
 are overwritten by the corresponding input in `automl-execution` if

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -5,35 +5,38 @@
 (check-excluded-fields train-dataset automl-execution excluded-fields)
 (log-info "Checking input dataset fields")
 (check-datasets-fields train-dataset validation-dataset test-dataset)
+(log-info "Checking excluded-models")
+(check-excluded-models excluded-models)
 
 ;; Whether we should reuse resources from a given execution
 (define reuse-resources (not (= (resource-type train-dataset) "dataset")))
 (log-featured "Feature generation")
 (log-info "Obtaining unsupervised models")
 ;; Returns a list of unsupervised-models from a dataset
-(define (create-unsupervised-models dataset excluded)
+(define (create-unsupervised-models dataset excluded excluded-models)
   (let (params {"excluded_fields" (field-ids-from-names excluded dataset)}
         objective-id (dataset-get-objective-id dataset)
         lev-params (merge params {"rhs_predicate" [{"field" objective-id}]
                                   "search_strategy" "leverage"})
         lift-params (merge params {"rhs_predicate" [{"field" objective-id}]
                                    "search_strategy" "lift"})
-        all-models [(create-unsupervised "association" dataset lev-params false)
-                    (create-unsupervised "association" dataset lift-params false)
-                    (create-unsupervised "cluster" dataset params true)
-                    (create-unsupervised "anomaly" dataset params true)
-                    (create-unsupervised "pca" dataset params true)
-                    (create-unsupervised "topicmodel" dataset params true)])
+        all-models
+        (map (lambda (type params*)
+               (when (create-unsupervised? type excluded-models)
+                 (create-unsupervised type dataset params*)))
+        ["association" "association" "cluster" "anomaly" "pca" "topicmodel"]
+        [lev-params lift-params params params params params]))
     (remove-false all-models)))
 
 ;; Returns a list of unsupervised model from an execution output
-(define (get-unsupervised-models automl-exec)
-  (output-from-exec automl-exec "unsupervised-models"))
+(define (get-unsupervised-models automl-exec excluded-models)
+  (filter (lambda(m)(create-unsupervised? (resource-type m) excluded-models))
+          (output-from-exec automl-exec "unsupervised-models")))
 ;; List that contains all the created unsupervised models
 (define unsupervised-models
   (if reuse-resources
-    (get-unsupervised-models automl-execution)
-    (create-unsupervised-models train-dataset excluded-fields)))
+    (get-unsupervised-models automl-execution excluded-models)
+    (create-unsupervised-models train-dataset excluded-fields excluded-models)))
 
 (log-info "Generating new features from unsupervised models")
 (define (feature-generation dataset-id model-list excluded)

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -9,10 +9,12 @@
   (let (get-value (lambda(input) (if reuse-resources
                                    (input-from-exec automl-execution name)
                                    input)))
-    (cond (= name "excluded-fields") (get-value excluded-fields)
-          (= name "excluded-models") (get-value excluded-models)
-          (= name "pca-variance-threshold") (get-value pca-variance-threshold)
-          (= name "leverage-threshold") (get-value leverage-threshold))))
+    (cond (= name "excluded-fields") (or (get-value excluded-fields) [])
+          (= name "excluded-models") (or (get-value excluded-models) [])
+          (= name "pca-variance-threshold") (or (get-value pca-variance-threshold)
+                                                1)
+          (= name "leverage-threshold") (or (get-value leverage-threshold)
+                                            0))))
 
 (log-featured "Initial checks")
 (log-info "Checking execution input datasets")

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -33,7 +33,7 @@
 (check-excluded-models (config "excluded-models"))
 (log-info "More configuration parameters checks")
 (check-params (config "pca-variance-threshold")
-              (config "leverage-threshold"))
+              (config "max-rules"))
 
 (log-featured "Feature generation")
 (log-info "Obtaining unsupervised models")
@@ -71,7 +71,7 @@
                             model-list
                             excluded
                             pca-threshold
-                            leverage-threshold)
+                            max-rules)
   (let (excluded (remove-false (field-ids-from-names excluded dataset-id))
         objective-id (dataset-get-objective-id dataset-id)
         name (resource-name dataset-id)
@@ -86,12 +86,12 @@
         anomaly-fields (feat-gen "anomaly" "batchanomalyscore" {})
         topic-fields (feat-gen "topicmodel" "batchtopicdistribution" {})
         pca-params {"variance_threshold" pca-threshold}
-        pca-fields (feat-gen "pca""batchprojection" pca-params)
+        pca-fields (feat-gen "pca" "batchprojection" pca-params)
         dataset-assoc (assoc-feature-gen dataset-id
                                          model-list
                                          name
                                          excluded
-                                         leverage-threshold)
+                                         max-rules)
         all-fields [cluster-fields anomaly-fields topic-fields pca-fields]
         all-ds (cons dataset-assoc (map batch-output-ds all-fields)))
     (feature-generation-dataset all-ds name objective-id)))
@@ -99,7 +99,7 @@
 (define extended-datasets
   (let (exc-fields (config "excluded-fields")
         pca-threshold (config "pca-variance-threshold")
-        lev-threshold (config "leverage-threshold"))
+        max-rules (config "max-rules"))
     (map (lambda(dataset)
            (when (= (resource-type dataset) "dataset")
              (log-info " - Extending dataset: " (resource-name dataset))
@@ -107,7 +107,7 @@
                                  unsupervised-models
                                  exc-fields
                                  pca-threshold
-                                 lev-threshold)))
+                                 max-rules)))
          [train-dataset validation-dataset test-dataset])))
 
 

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -1,5 +1,5 @@
 (log-featured "Initial checks")
-(log-info "Checking execution inputs")
+(log-info "Checking execution input datasets")
 (check-inputs train-dataset validation-dataset test-dataset automl-execution)
 (log-info "Checking excluded fields")
 (check-excluded-fields train-dataset automl-execution excluded-fields)
@@ -7,6 +7,8 @@
 (check-datasets-fields train-dataset validation-dataset test-dataset)
 (log-info "Checking excluded-models")
 (check-excluded-models excluded-models)
+(log-info "Checking the rest of input parameters")
+(check-params pca-variance-threshold)
 
 ;; Whether we should reuse resources from a given execution
 (define reuse-resources (not (= (resource-type train-dataset) "dataset")))
@@ -39,25 +41,34 @@
     (create-unsupervised-models train-dataset excluded-fields excluded-models)))
 
 (log-info "Generating new features from unsupervised models")
-(define (feature-generation dataset-id model-list excluded)
+(define (feature-generation dataset-id model-list excluded threshold)
   (let (excluded (remove-false (field-ids-from-names excluded dataset-id))
         objective-id (dataset-get-objective-id dataset-id)
         name (resource-name dataset-id)
-        feat-gen (lambda (m b)
-                   (unsupervised-feature-gen dataset-id model-list name m b))
-        cluster-fields (feat-gen "cluster" "batchcentroid")
-        anomaly-fields (feat-gen "anomaly" "batchanomalyscore")
-        topic-fields (feat-gen "topicmodel" "batchtopicdistribution")
-        pca-fields (feat-gen "pca" "batchprojection")
+        feat-gen (lambda (model-type batch-type params)
+                   (unsupervised-feature-gen dataset-id
+                                             model-list
+                                             name
+                                             model-type
+                                             batch-type
+                                             params))
+        cluster-fields (feat-gen "cluster" "batchcentroid" {})
+        anomaly-fields (feat-gen "anomaly" "batchanomalyscore" {})
+        topic-fields (feat-gen "topicmodel" "batchtopicdistribution" {})
+        pca-params {"variance_threshold" threshold}
+        pca-fields (feat-gen "pca""batchprojection" pca-params)
         dataset-assoc (assoc-feature-gen dataset-id  model-list name excluded)
         all-fields [cluster-fields anomaly-fields topic-fields pca-fields]
         all-ds (cons dataset-assoc (map batch-output-ds all-fields)))
     (feature-generation-dataset all-ds name objective-id)))
 
 (define extended-datasets
-  (map (lambda(d) (when (= (resource-type d) "dataset")
-                    (log-info " - Extending dataset: " (resource-name d))
-                    (feature-generation d unsupervised-models excluded-fields)))
+  (map (lambda(dataset) (when (= (resource-type dataset) "dataset")
+                    (log-info " - Extending dataset: " (resource-name dataset))
+                    (feature-generation dataset
+                                        unsupervised-models
+                                        excluded-fields
+                                        pca-variance-threshold)))
        [train-dataset validation-dataset test-dataset]))
 
 

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -8,7 +8,7 @@
 (log-info "Checking excluded-models")
 (check-excluded-models excluded-models)
 (log-info "Checking the rest of input parameters")
-(check-params pca-variance-threshold)
+(check-params pca-variance-threshold leverage-threshold)
 
 ;; Whether we should reuse resources from a given execution
 (define reuse-resources (not (= (resource-type train-dataset) "dataset")))
@@ -41,7 +41,11 @@
     (create-unsupervised-models train-dataset excluded-fields excluded-models)))
 
 (log-info "Generating new features from unsupervised models")
-(define (feature-generation dataset-id model-list excluded threshold)
+(define (feature-generation dataset-id
+                            model-list
+                            excluded
+                            pca-threshold
+                            leverage-threshold)
   (let (excluded (remove-false (field-ids-from-names excluded dataset-id))
         objective-id (dataset-get-objective-id dataset-id)
         name (resource-name dataset-id)
@@ -55,9 +59,13 @@
         cluster-fields (feat-gen "cluster" "batchcentroid" {})
         anomaly-fields (feat-gen "anomaly" "batchanomalyscore" {})
         topic-fields (feat-gen "topicmodel" "batchtopicdistribution" {})
-        pca-params {"variance_threshold" threshold}
+        pca-params {"variance_threshold" pca-threshold}
         pca-fields (feat-gen "pca""batchprojection" pca-params)
-        dataset-assoc (assoc-feature-gen dataset-id  model-list name excluded)
+        dataset-assoc (assoc-feature-gen dataset-id
+                                         model-list
+                                         name
+                                         excluded
+                                         leverage-threshold)
         all-fields [cluster-fields anomaly-fields topic-fields pca-fields]
         all-ds (cons dataset-assoc (map batch-output-ds all-fields)))
     (feature-generation-dataset all-ds name objective-id)))
@@ -68,7 +76,8 @@
                     (feature-generation dataset
                                         unsupervised-models
                                         excluded-fields
-                                        pca-variance-threshold)))
+                                        pca-variance-threshold
+                                        leverage-threshold)))
        [train-dataset validation-dataset test-dataset]))
 
 

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -99,7 +99,7 @@
 (define extended-datasets
   (let (exc-fields (config "excluded-fields")
         pca-threshold (config "pca-variance-threshold")
-        max-rules (config "max-rules"))
+        max-rules (floor (config "max-rules")))
     (map (lambda(dataset)
            (when (= (resource-type dataset) "dataset")
              (log-info " - Extending dataset: " (resource-name dataset))

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -1,17 +1,35 @@
+;; Whether we should reuse resources from a given execution
+(define reuse-resources (not (= (resource-type train-dataset) "dataset")))
+
+;; Get the value of an input parameter from the current execution, or
+;; from a previous execution if it is given
+;; Configuration parameters from automl-execution overwrite the ones
+;; given by the user in the current execution
+(define (get-input name)
+  (let (get-value (lambda(input) (if reuse-resources
+                                   (input-from-exec automl-execution name)
+                                   input)))
+    (cond (= name "excluded-fields") (get-value excluded-fields)
+          (= name "excluded-models") (get-value excluded-models)
+          (= name "pca-variance-threshold") (get-value pca-variance-threshold)
+          (= name "leverage-threshold") (get-value leverage-threshold))))
+
 (log-featured "Initial checks")
 (log-info "Checking execution input datasets")
 (check-inputs train-dataset validation-dataset test-dataset automl-execution)
-(log-info "Checking excluded fields")
-(check-excluded-fields train-dataset automl-execution excluded-fields)
 (log-info "Checking input dataset fields")
 (check-datasets-fields train-dataset validation-dataset test-dataset)
+(log-info "Checking configuration inputs")
+(map (lambda(i name) (check-config-input i (get-input name) name))
+     [excluded-fields excluded-models pca-variance-threshold leverage-threshold]
+     ["excluded-fields" "excluded-models" "pca-variance-threshold"
+      "leverage-threshold"])
 (log-info "Checking excluded-models")
-(check-excluded-models excluded-models)
-(log-info "Checking the rest of input parameters")
-(check-params pca-variance-threshold leverage-threshold)
+(check-excluded-models (get-input "excluded-models"))
+(log-info "More configuration parameters checks")
+(check-params (get-input "pca-variance-threshold")
+              (get-input "leverage-threshold"))
 
-;; Whether we should reuse resources from a given execution
-(define reuse-resources (not (= (resource-type train-dataset) "dataset")))
 (log-featured "Feature generation")
 (log-info "Obtaining unsupervised models")
 ;; Returns a list of unsupervised-models from a dataset
@@ -34,11 +52,14 @@
 (define (get-unsupervised-models automl-exec excluded-models)
   (filter (lambda(m)(create-unsupervised? (resource-type m) excluded-models))
           (output-from-exec automl-exec "unsupervised-models")))
+
 ;; List that contains all the created unsupervised models
 (define unsupervised-models
-  (if reuse-resources
-    (get-unsupervised-models automl-execution excluded-models)
-    (create-unsupervised-models train-dataset excluded-fields excluded-models)))
+  (let (exc-fields (get-input "excluded-fields")
+        exc-models (get-input "excluded-models"))
+    (if reuse-resources
+      (get-unsupervised-models automl-execution exc-models)
+      (create-unsupervised-models train-dataset exc-fields exc-models))))
 
 (log-info "Generating new features from unsupervised models")
 (define (feature-generation dataset-id
@@ -71,14 +92,18 @@
     (feature-generation-dataset all-ds name objective-id)))
 
 (define extended-datasets
-  (map (lambda(dataset) (when (= (resource-type dataset) "dataset")
-                    (log-info " - Extending dataset: " (resource-name dataset))
-                    (feature-generation dataset
-                                        unsupervised-models
-                                        excluded-fields
-                                        pca-variance-threshold
-                                        leverage-threshold)))
-       [train-dataset validation-dataset test-dataset]))
+  (let (exc-fields (get-input "excluded-fields")
+        pca-threshold (get-input "pca-variance-threshold")
+        lev-threshold (get-input "leverage-threshold"))
+    (map (lambda(dataset)
+           (when (= (resource-type dataset) "dataset")
+             (log-info " - Extending dataset: " (resource-name dataset))
+             (feature-generation dataset
+                                 unsupervised-models
+                                 exc-fields
+                                 pca-threshold
+                                 lev-threshold)))
+         [train-dataset validation-dataset test-dataset])))
 
 
 (log-featured "Feature Selection")

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -1,36 +1,39 @@
 ;; Whether we should reuse resources from a given execution
 (define reuse-resources (not (= (resource-type train-dataset) "dataset")))
-
-;; Get the value of an input parameter from the current execution, or
-;; from a previous execution if it is given
-;; Configuration parameters from automl-execution overwrite the ones
+;; Get the value of an input parameter from the current
+;; execution, or from a previous execution if it is given
+;; Input parameters from automl-execution overwrite the ones
 ;; given by the user in the current execution
 (define (get-input name)
   (let (get-value (lambda(input) (if reuse-resources
                                    (input-from-exec automl-execution name)
                                    input)))
-    (cond (= name "excluded-fields") (or (get-value excluded-fields) [])
-          (= name "excluded-models") (or (get-value excluded-models) [])
-          (= name "pca-variance-threshold") (or (get-value pca-variance-threshold)
-                                                1)
-          (= name "leverage-threshold") (or (get-value leverage-threshold)
-                                            0))))
+    (cond (= name "configuration-params") (get-value configuration-params)
+          (= name "train-dataset") (get-value train-dataset))))
+
+;; Execution configuration parameters
+(define config (get-input "configuration-params"))
+
+(when (not (= config configuration-params))
+  (log-warn "WARNING: Configuration params from the automl-execution "
+            " overwrite the given params")
+  (log-info "Configuration used: ")
+  (log-info config))
 
 (log-featured "Initial checks")
 (log-info "Checking execution input datasets")
 (check-inputs train-dataset validation-dataset test-dataset automl-execution)
 (log-info "Checking input dataset fields")
-(check-datasets-fields train-dataset validation-dataset test-dataset)
-(log-info "Checking configuration inputs")
-(map (lambda(i name) (check-config-input i (get-input name) name))
-     [excluded-fields excluded-models pca-variance-threshold leverage-threshold]
-     ["excluded-fields" "excluded-models" "pca-variance-threshold"
-      "leverage-threshold"])
+(check-datasets-fields (get-input "train-dataset")
+                       validation-dataset
+                       test-dataset)
+(log-info "Check configuration params")
+(check-configuration-params config)
 (log-info "Checking excluded-models")
-(check-excluded-models (get-input "excluded-models"))
+(check-excluded-models (config "excluded-models"))
 (log-info "More configuration parameters checks")
-(check-params (get-input "pca-variance-threshold")
-              (get-input "leverage-threshold"))
+(check-params (config "pca-variance-threshold")
+              (config "leverage-threshold"))
 
 (log-featured "Feature generation")
 (log-info "Obtaining unsupervised models")
@@ -57,8 +60,8 @@
 
 ;; List that contains all the created unsupervised models
 (define unsupervised-models
-  (let (exc-fields (get-input "excluded-fields")
-        exc-models (get-input "excluded-models"))
+  (let (exc-fields (config "excluded-fields")
+        exc-models (config "excluded-models"))
     (if reuse-resources
       (get-unsupervised-models automl-execution exc-models)
       (create-unsupervised-models train-dataset exc-fields exc-models))))
@@ -94,9 +97,9 @@
     (feature-generation-dataset all-ds name objective-id)))
 
 (define extended-datasets
-  (let (exc-fields (get-input "excluded-fields")
-        pca-threshold (get-input "pca-variance-threshold")
-        lev-threshold (get-input "leverage-threshold"))
+  (let (exc-fields (config "excluded-fields")
+        pca-threshold (config "pca-variance-threshold")
+        lev-threshold (config "leverage-threshold"))
     (map (lambda(dataset)
            (when (= (resource-type dataset) "dataset")
              (log-info " - Extending dataset: " (resource-name dataset))


### PR DESCRIPTION
This PR adds a new configuration input parameter with some parameters that
let the user exclude some fields or models or filter the features that are added 
to the original dataset from the unsupervised models.

In the near future, some new configuration parameters may be added for other
unsupervised models.