### PR TITLE
Avoid use of non-preferred fields in AutoML

### DIFF
--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -1,5 +1,5 @@
 ;;;;;;;;;;;;;;;;;;;;;;; AUTOML LIBRARY ;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;; library version 0.3 ;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;; library version 0.4 ;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;; Private functions start with _ ;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;; Check automl script ;;;;;;;;;;;;;;;;;;;;;
 
@@ -40,10 +40,6 @@
   (when (list? items)
     (filter (lambda (n) n) items)))
 
-(define (_flatten items)
-  (when (and (list? items) (not (empty? items)))
-    (if (every? list? items) (_flatten (reduce concat [] items)) items)))
-
 (define (_model-from-list model-list model-type)
   (when (list? model-list)
     (filter (lambda (m) (= (resource-type m) model-type))
@@ -53,14 +49,6 @@
   (try (delete id)
        (catch e
          (log-info  "Error deleting resource " id " ignored"))))
-
-;; Return list of field ids of non-preferred fields
-;; from a given dataset
-(define (non-preferred dataset-id)
-  (when (= (resource-type dataset-id) "dataset")
-    (let (fields (resource-fields dataset-id))
-      (filter (lambda (k) (not (fields [k "preferred"] true)))
-              (keys fields)))))
 
 ;; Returns a list of field ids from a list of field names
 ;; Not found fields are ignored
@@ -76,7 +64,21 @@
   (let (dataset-fields (resource-fields dataset))
     (remove-false
      (map (lambda(f) (get (or (find-field dataset-fields f) {}) "name" false))
-          field-ids))))
+          (or field-ids [])))))
+
+;; Return list of field ids of non-preferred fields
+;; from a given dataset
+(define (non-preferred dataset-id)
+  (when (= (resource-type dataset-id) "dataset")
+    (let (fields (resource-fields dataset-id))
+      (filter (lambda (k) (not (fields [k "preferred"] true)))
+              (keys fields)))))
+
+;; Set a list of fields from a dataset as non-preferred
+(define (set-non-preferred dataset-id field-names)
+  (let (fids (field-ids-from-names field-names dataset-id)
+        fvalues (repeat (count fids) {"preferred" false}))
+    (update dataset-id {"fields" (make-map fids fvalues)})))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;; CHECKS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -360,7 +362,7 @@
         new-fields
         (map (lambda(m) (_batch-association-sets dataset-id m "antecedent" rules))
                         (_model-from-list model-list "association")))
-    (_dataset-with-rules dataset-id name (_flatten new-fields) excluded)))
+    (_dataset-with-rules dataset-id name (flatten new-fields) excluded)))
 
 ;; From a batch score, obtains the generated output dataset
 (define (batch-output-ds res)
@@ -368,11 +370,13 @@
     ((fetch (wait res)) "output_dataset_resource" false)))
 
 ;; Creates a new dataset by juxtaposing a list of datasets
-(define (feature-generation-dataset ds-list name objective-id)
-  (update (create-dataset {"origin_datasets" (remove-false ds-list)
-                           "juxtapose" true
-                           "name" (str name " | extended")})
-          {"objective_field" {"id" objective-id}}))
+(define (feature-generation-dataset ds-list name objective-id non-pref)
+  (let (params {"origin_datasets" (remove-false ds-list)
+                "juxtapose" true
+                "name" (str name " | extended")})
+  (set-non-preferred (update (create-dataset params)
+                             {"objective_field" {"id" objective-id}})
+                     non-pref)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;; FEATURE  SELECTION ;;;;;;;;;;;;;;;;;;;;;;
@@ -498,7 +502,7 @@
     (log-info "Finished feature selection")
     (log-info "Removing " (count excluded) " features")
     (log-info "Using " num-features " features")
-    (_filter-dataset-fields dataset (_flatten excluded))))
+    (_filter-dataset-fields dataset (flatten excluded))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;; MODEL  SELECTION ;;;;;;;;;;;;;;;;;;;;;;

--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -1,5 +1,5 @@
 ;;;;;;;;;;;;;;;;;;;;;;; AUTOML LIBRARY ;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;; library version 0.2 ;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;; library version 0.3 ;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;; Private functions start with _ ;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;; Check automl script ;;;;;;;;;;;;;;;;;;;;;
 
@@ -53,6 +53,14 @@
   (try (delete id)
        (catch e
          (log-info  "Error deleting resource " id " ignored"))))
+
+;; Return list of field ids of non-preferred fields
+;; from a given dataset
+(define (non-preferred dataset-id)
+  (when (= (resource-type dataset-id) "dataset")
+    (let (fields (resource-fields dataset-id))
+      (filter (lambda (k) (not (fields [k "preferred"] true)))
+              (keys fields)))))
 
 ;; Returns a list of field ids from a list of field names
 ;; Not found fields are ignored
@@ -314,14 +322,14 @@
 (define (_dataset-with-rules dataset-id dataset-name new-fields excluded)
   (when (= (resource-type dataset-id) "dataset")
     (let (params {"origin_dataset" dataset-id
-                     "excluded_fields" excluded
-                     "name" (str dataset-name " | with-assoc-rules")}
+                  "excluded_fields" excluded
+                  "name" (str dataset-name " | with-assoc-rules")}
           final-params (if (and (list? new-fields) (not (empty? new-fields)))
                          (merge params
                                 {"new_fields"
                                  (or (_remove-duplicate-rules new-fields) [])})
                          params))
-    (create-dataset final-params))))
+      (create-dataset final-params))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;; FEATURE  GENERATION ;;;;;;;;;;;;;;;;;;;;;

--- a/automl/automl-script/readme.md
+++ b/automl/automl-script/readme.md
@@ -69,8 +69,8 @@ is given.
 
 **WARNING** All the fields that appear as `non-preferred` in train,
 validation or test datasets will be considered `non-preferred` in all
-the resources created by AutoML. It doesn't matter if they are set as
-non-preferred in train, validation or test dataset.
+the resources created by AutoML. It doesn't matter in which dataset
+(train, validation or test) they are set as non-preferred fields.
 
 The **outputs** for the script are:
 * `output-dataset`: (dataset-id) Dataset with final predictions for the test dataset

--- a/automl/automl-script/readme.md
+++ b/automl/automl-script/readme.md
@@ -63,9 +63,14 @@ The **inputs** for the script are:
     association discovery models or if the same rules appear on more
     than one association discovery model.
 
-**WARNING** Remember that, to avoid confusion, `configuration-params`
-are overwritten by the corresponding input in `automl-execution` if
-this is given.
+**WARNING** To avoid confusion, `configuration-params` are always
+overwritten by the corresponding input in `automl-execution` if this
+is given.
+
+**WARNING** All the fields that appear as `non-preferred` in train,
+validation or test datasets will be considered `non-preferred` in all
+the resources created by AutoML. It doesn't matter if they are set as
+non-preferred in train, validation or test dataset.
 
 The **outputs** for the script are:
 * `output-dataset`: (dataset-id) Dataset with final predictions for the test dataset

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -39,7 +39,9 @@
 (log-info "Obtaining unsupervised models")
 ;; Returns a list of unsupervised-models from a dataset
 (define (create-unsupervised-models dataset excluded excluded-models)
-  (let (params {"excluded_fields" (field-ids-from-names excluded dataset)}
+  (let (params {"excluded_fields"
+                (concat (non-preferred dataset)
+                        (field-ids-from-names excluded dataset))}
         objective-id (dataset-get-objective-id dataset)
         lev-params (merge params {"rhs_predicate" [{"field" objective-id}]
                                   "search_strategy" "leverage"})
@@ -72,7 +74,9 @@
                             excluded
                             pca-threshold
                             max-rules)
-  (let (excluded (remove-false (field-ids-from-names excluded dataset-id))
+  (let (excluded (concat (non-preferred dataset-id)
+                         (remove-false (field-ids-from-names excluded
+                                                             dataset-id)))
         objective-id (dataset-get-objective-id dataset-id)
         name (resource-name dataset-id)
         feat-gen (lambda (model-type batch-type params)

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -35,13 +35,23 @@
 (check-params (config "pca-variance-threshold")
               (config "max-rules"))
 
+;; Retrieve all non-preferred fields from all the datasets
+(define non-preferred-fields
+  (remove-duplicates
+   (flatten
+    (map (lambda(ds) (field-names-from-ids (non-preferred ds) ds))
+         [(get-input "train-dataset") validation-dataset test-dataset]))))
+
+(log-info "These fields will be set as non-preferred:")
+(log-info non-preferred-fields)
+
+
 (log-featured "Feature generation")
 (log-info "Obtaining unsupervised models")
 ;; Returns a list of unsupervised-models from a dataset
 (define (create-unsupervised-models dataset excluded excluded-models)
-  (let (params {"excluded_fields"
-                (concat (non-preferred dataset)
-                        (field-ids-from-names excluded dataset))}
+  (let (_ (set-non-preferred dataset non-preferred-fields)
+        params {"excluded_fields" (field-ids-from-names excluded dataset)}
         objective-id (dataset-get-objective-id dataset)
         lev-params (merge params {"rhs_predicate" [{"field" objective-id}]
                                   "search_strategy" "leverage"})
@@ -74,9 +84,7 @@
                             excluded
                             pca-threshold
                             max-rules)
-  (let (excluded (concat (non-preferred dataset-id)
-                         (remove-false (field-ids-from-names excluded
-                                                             dataset-id)))
+  (let (excluded (remove-false (field-ids-from-names excluded dataset-id))
         objective-id (dataset-get-objective-id dataset-id)
         name (resource-name dataset-id)
         feat-gen (lambda (model-type batch-type params)
@@ -98,7 +106,7 @@
                                          max-rules)
         all-fields [cluster-fields anomaly-fields topic-fields pca-fields]
         all-ds (cons dataset-assoc (map batch-output-ds all-fields)))
-    (feature-generation-dataset all-ds name objective-id)))
+    (feature-generation-dataset all-ds name objective-id non-preferred-fields)))
 
 (define extended-datasets
   (let (exc-fields (config "excluded-fields")


### PR DESCRIPTION
Non-preferred fields are now ignored during the unsupervised models
generation step and during the creation of the extended dataset, so
we don't need to ignore them in the feature selection step because
they have already been ignored previously.

Non-preferred fields have the same behavior now as if the user had set
them in the excluded-fields configuration parameter.