### PR TITLE
Avoid problems with anti html injection systems

### DIFF
--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -1,5 +1,5 @@
 ;;;;;;;;;;;;;;;;;;;;;;; AUTOML LIBRARY ;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;; library version 0.5 ;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;; library version 0.6 ;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;; Private functions start with _ ;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;; Check automl script ;;;;;;;;;;;;;;;;;;;;;
 
@@ -200,12 +200,12 @@
     (if (item "name" false)
       (cond (and (numeric-field? field-info) start end)
             (if (< start end)
-              (str start " < " field-name " <= " end)
-              (str field-name " > " start " or <=" end))
+              (str start " ＜ " field-name " ＜= " end)
+              (str field-name " ＞ " start " or ＜=" end))
             (and (numeric-field? field-info) start)
-            (str field-name " > " start)
+            (str field-name " ＞ " start)
             (and (numeric-field? field-info) end)
-            (str field-name " <= " end)
+            (str field-name " ＜= " end)
             (categorical-field? field-info)
             (str field-name " " (if complement? "!=" "=")
                  " " (item "name"))
@@ -329,7 +329,8 @@
                         (some (lambda(saved-rule)
                                 (= (saved-rule "name") (rule "name")))
                               rules)))
-      (reduce (lambda (l r) (if (not (rule-exists r l) ) (cons r l) l)) []
+      (reduce (lambda (l r) (if (not (rule-exists r l)) (cons r l) l))
+              []
               rules))))
 
 (define (_dataset-with-rules dataset-id dataset-name new-fields excluded)
@@ -372,7 +373,7 @@
   (let (rules (floor (/ num-of-rules 2))
         new-fields
         (map (lambda(m) (_batch-association-sets dataset-id m "antecedent" rules))
-                        (_model-from-list model-list "association")))
+             (_model-from-list model-list "association")))
     (_dataset-with-rules dataset-id name (flatten new-fields) excluded)))
 
 ;; From a batch score, obtains the generated output dataset

--- a/automl/automl-script/metadata.json
+++ b/automl/automl-script/metadata.json
@@ -28,7 +28,7 @@
       "name": "automl-execution",
       "type": "execution-id",
       "default": "",
-      "description": "Previous execution of this script, to reuse created resources, e.g. execution/5d272205eba31d61920005cd"
+      "description": "For test executions. Previous execution of this script, to reuse created resources during training, e.g. execution/5d272205eba31d61920005cd"
     },
     {
       "name": "models-configuration",

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -173,12 +173,13 @@
 ;; Creates the filtered datasets from the extended datasets,
 ;; filtering out all the fields not present in selected-fields list
 (define filtered-datasets
-  (map (lambda (ds) (when (= "dataset" (resource-type ds))
-                      (let (name (str (resource-name ds) " | filtered")
-                            fields (field-ids-from-names selected-fields ds))
-                        (create-dataset {"name" name
-                                         "origin_dataset" ds
-                                         "input_fields" fields}))))
+  (map (lambda (ds)
+         (when (= "dataset" (resource-type ds))
+           (let (name (str (resource-name ds) " | filtered")
+                 fields (field-ids-from-names selected-fields ds))
+             (create-dataset {"name" name
+                              "origin_dataset" ds
+                              "input_fields" (remove-duplicates fields)}))))
        extended-datasets))
 
 (log-featured "Model Selection")


### PR DESCRIPTION
Names of features comming from Association Discoveries were causing
problems because they contain < and > characters (used in HTML tags) and
they were removed by BigML anti injection systems.

Now, these characters have been replaced with ＜ and ＞.