### PR TITLE
Configure AutoML complexity

### DIFF
--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -46,9 +46,10 @@
             model-list)))
 
 (define (_safe-delete id)
-  (try (delete id)
-       (catch e
-         (log-info  "Error deleting resource " id " ignored"))))
+  (when id
+    (try (delete id)
+         (catch e
+           (log-info  "Error deleting resource " id " ignored")))))
 
 ;; Returns a list of field ids from a list of field names
 ;; Not found fields are ignored
@@ -531,7 +532,7 @@
 (define (create-optiml-model train validation params shallow)
   (when (= (resource-type train) "dataset")
     (log-info "Creating Optiml, this  can last several minutes (or even hours)")
-    (let (max-time {"max_training_time" (if shallow 900 1800)}
+    (let (max-time {"max_training_time" (if shallow 900 3600)}
           params (merge params
                         (if (= (resource-type validation) "dataset")
                           (merge max-time {"test_dataset" validation})

--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -1,5 +1,5 @@
 ;;;;;;;;;;;;;;;;;;;;;;; AUTOML LIBRARY ;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;; library version 0.6 ;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;; library version 0.7 ;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;; Private functions start with _ ;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;; Check automl script ;;;;;;;;;;;;;;;;;;;;;
 
@@ -96,9 +96,9 @@
 ;; Checks that all the needed params are in the configuration
 (define (check-configuration-params config)
   (let (correct #["excluded-fields" "excluded-models"
-                  "pca-variance-threshold" "max-rules"
+                  "pca-variance-threshold" "max-association-rules"
                   "validation-rate" "balance-objective"
-                  "configuration-params"]
+                  "models-configuration"]
         dif (difference correct (set* (keys (or config {})))))
     (when (not (empty? dif))
       (raise (str "Can't find the following parameters in the "
@@ -370,9 +370,8 @@
 ;; association sets from association discovery models in model-list
 ;; User can also set a list of fields to be excluded and a maximum
 ;; number of rules that should be obtained
-(define (assoc-feature-gen dataset-id model-list name excluded num-of-rules)
-  (let (rules (floor (/ num-of-rules 2))
-        new-fields
+(define (assoc-feature-gen dataset-id model-list name excluded rules)
+  (let (new-fields
         (map (lambda(m) (_batch-association-sets dataset-id m "antecedent" rules))
              (_model-from-list model-list "association")))
     (_dataset-with-rules dataset-id name (flatten new-fields) excluded)))
@@ -448,8 +447,7 @@
 
 ;; Applies recursive feature elimination to obtain the most important
 ;; fields from a dataset, evaluating each iteration with the test-ds-id
-(define (recursive-feature-elimination ds-id nfeatures obj-id
-                                       test-ds-id metric balance)
+(define (rfe ds-id nfeatures obj-id test-ds-id metric balance)
   (let (do-evaluation (= (resource-type test-ds-id) "dataset")
         [obj-id otype] (_get-objective ds-id obj-id)
         fields (resource-fields ds-id)
@@ -510,14 +508,18 @@
        "features"))
 
 ;; Filters out the unimportant fields from a dataset
-(define (rfe-output-fields dataset evaluations num-features)
-  (let (excluded (map (lambda (n) (n "last-removed"))
+(define (rfe-output-fields dataset rfe-output num-features shallow)
+  (let (evaluations (rfe-output "evaluations" {})
+        selected (rfe-output "selected-fields")
+        objective  (dataset-get-objective-id dataset)
+        excluded (map (lambda (n) (n "last-removed"))
                       (filter (lambda (n) (> (n "features") num-features))
                               evaluations)))
     (log-info "Finished feature selection")
-    (log-info "Removing " (count excluded) " features")
     (log-info "Using " num-features " features")
-    (_filter-dataset-fields dataset (flatten excluded))))
+    (if shallow
+      (field-names-from-ids (append selected objective) dataset)
+      (_filter-dataset-fields dataset (flatten excluded)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;; MODEL  SELECTION ;;;;;;;;;;;;;;;;;;;;;;
@@ -526,12 +528,15 @@
 
 ;; Creates an optiml model from a train and an
 ;; optional validation dataset
-(define (create-optiml-model train validation params)
+(define (create-optiml-model train validation params shallow)
   (when (= (resource-type train) "dataset")
     (log-info "Creating Optiml, this  can last several minutes (or even hours)")
-    (create-optiml train (if (= (resource-type validation) "dataset")
-                           (merge params {"test_dataset" validation})
-                           params))))
+    (let (max-time {"max_training_time" (if shallow 900 1800)}
+          params (merge params
+                        (if (= (resource-type validation) "dataset")
+                          (merge max-time {"test_dataset" validation})
+                          max-time)))
+      (create-optiml train params))))
 
 ;; Obtains a fusion from the outpus of an execution
 (define (retrieve-fusion exec)

--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -97,7 +97,8 @@
 (define (check-configuration-params config)
   (let (correct #["excluded-fields" "excluded-models"
                   "pca-variance-threshold" "max-rules"
-                  "validation-rate" "balance-objective"]
+                  "validation-rate" "balance-objective"
+                  "configuration-params"]
         dif (difference correct (set* (keys (or config {})))))
     (when (not (empty? dif))
       (raise (str "Can't find the following parameters in the "

--- a/automl/automl-script/metadata.json
+++ b/automl/automl-script/metadata.json
@@ -31,20 +31,21 @@
       "description": "For test executions. Previous execution of this script, to reuse created resources during training, e.g. execution/5d272205eba31d61920005cd"
     },
     {
-      "name": "models-configuration",
-      "type": "map",
-      "default": {},
-      "description": "Configuration parameters for created models. See README for more information"
+      "name": "shallow-search",
+      "type": "boolean",
+      "default": false,
+      "description": "If true, AutoML will perform a more shallow (but faster) search of the best features and models"
     },
     {
       "name": "configuration-params",
       "type": "map",
       "default": {"excluded-fields": [],
                   "excluded-models": [],
-                  "pca-variance-threshold": 1,
-                  "max-rules": 20,
+                  "pca-variance-threshold": 0.6,
+                  "max-associations-rules": 20,
                   "validation-rate": 0.2,
-                  "balance-objective": false},
+                  "balance-objective": false,
+                  "models-configuration": {}},
       "description": "Execution configuration parameters. They will be overwritten if automl-execution is given. See README for more information"
     }
   ],

--- a/automl/automl-script/metadata.json
+++ b/automl/automl-script/metadata.json
@@ -33,7 +33,7 @@
     {
       "name": "shallow-search",
       "type": "boolean",
-      "default": false,
+      "default": true,
       "description": "If true, AutoML will perform a more shallow (but faster) search of the best features and models"
     },
     {

--- a/automl/automl-script/metadata.json
+++ b/automl/automl-script/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "AutoML",
   "description":
-  "This script executes, in the correct order, all the steps from the BigML's Automated Machine Learning pipeline",
+  "This script executes all the steps from the BigML's Automated Machine Learning pipeline",
   "kind": "script",
   "source_code": "script.whizzml",
   "imports":["../automl-library"],
@@ -42,7 +42,7 @@
       "default": {"excluded-fields": [],
                   "excluded-models": [],
                   "pca-variance-threshold": 0.6,
-                  "max-associations-rules": 20,
+                  "max-association-rules": 10,
                   "validation-rate": 0.2,
                   "balance-objective": false,
                   "models-configuration": {}},

--- a/automl/automl-script/readme.md
+++ b/automl/automl-script/readme.md
@@ -47,7 +47,8 @@ The **inputs** for the script are:
   new resources are generated from the training data.
 * `shallow-search`: (boolean) If true, AutoML will perform a more
   shallow (but faster) search of the best features and models. A
-  ramdomly sampled dataset will be used in some stages of the process
+  ramdomly sampled dataset will be used in some stages of the process,
+  only one association discovery will be created (with lift metric)
   and the maximum training time of the OptiML will be more
   limited. Default value is `False`.
 * `configuration-params`: (map) Execution configuration
@@ -65,12 +66,12 @@ The **inputs** for the script are:
     variance is greater than the given threshold. Values from 0 to 1. A
     value of 1 means all the components will be used. Default value is
     0.8.
-  * `max-associations-rules`: (integer) Maximum number of association
-    rules that should be included in the extended datasets. Default
-    value is 20. The final number of rules added to the dataset can be
-    lower than this value if there aren't enough rules in the created
-    association discovery models or if the same rules appear on more
-    than one association discovery model.
+  * `max-association-rules`: (integer) Maximum number of association
+    rules that should be included in the extended datasets for each
+    association discovery created. Default value is 10. Please, note
+    that the final number of association rules in the extended
+    datasets can be higher than this value if more than one
+    association discovery is created.
   * `validation-rate`: (number) The portion of the `train-dataset`
     that is sampled in the `validation-dataset`. Values from 0 to 0.5.
     This is used only if a `validation-dataset` is not provided by the

--- a/automl/automl-script/readme.md
+++ b/automl/automl-script/readme.md
@@ -45,31 +45,30 @@ The **inputs** for the script are:
   `automl-execution` should be provided for the script to work. When
   both are provided, the `automl-execution` argument is discarded and
   new resources are generated from the training data.
-* `models-configuration`: (map) Configuration parameters for the models
-  created by AutoML. They won't be used if `automl-execution` is
-  given. The following keys are accepted: `cluster`, `anomaly`,
-  `association`, `pca`, `topicmodel`, `optiml`.
-  E.g. `{"cluster": {"critical_value": 4},
-         "anomaly": {"forest_size": 256},
-         "optiml": {"number_of_model_candidates": 64}}`
+* `shallow-search`: (boolean) If true, AutoML will perform a more
+  shallow (but faster) search of the best features and models. A
+  ramdomly sampled dataset will be used in some stages of the process
+  and the maximum training time of the OptiML will be more
+  limited. Default value is `False`.
 * `configuration-params`: (map) Execution configuration
   parameters. They will be overwritten if automl-execution is
   given. The following values must be provided:
   * `excluded-fields`: (list) List of fields that will be excluded
-  from any dataset before any other process starts. e.g. ["bmi",
-  "age"]. Empty by default.
+    from any dataset before any other process starts. e.g. ["bmi",
+    "age"]. Empty by default.
   * `excluded-models`: (list) List of unsupervised models that won't
-  be created nor reused during feature generation. e.g. ["anomaly",
-  "cluster"]. Possible values are: association, cluster, anomaly, pca
-  or topicmodel. Empty by default
+    be created nor reused during feature generation. e.g. ["anomaly",
+    "cluster"]. Possible values are: association, cluster, anomaly, pca
+    or topicmodel. Empty by default
   * `pca-variance-threshold`: (number) The PCA projection uses the
-  minimum number of components such that the cumulative explained
-  variance is greater than the given threshold. Values from 0 to 1.
-  Default value is 1 (all the components will be used)
-  * `max-rules`: (integer) Maximum number of association rules
-    that should be included in the extended datasets. Default value
-    is 20. The final number of rules added to the dataset can be lower
-    than this value if there aren't enough rules in the created
+    minimum number of components such that the cumulative explained
+    variance is greater than the given threshold. Values from 0 to 1. A
+    value of 1 means all the components will be used. Default value is
+    0.8.
+  * `max-associations-rules`: (integer) Maximum number of association
+    rules that should be included in the extended datasets. Default
+    value is 20. The final number of rules added to the dataset can be
+    lower than this value if there aren't enough rules in the created
     association discovery models or if the same rules appear on more
     than one association discovery model.
   * `validation-rate`: (number) The portion of the `train-dataset`
@@ -80,6 +79,13 @@ The **inputs** for the script are:
   * `balance-objective`: (boolean) Whether to balance classes
     proportionally to their category counts or not (during the
     creation of models). False by default.
+  * `models-configuration`:  (map) Configuration parameters for the models
+    created by AutoML. They won't be used if `automl-execution` is
+    given. The following keys are accepted: `cluster`, `anomaly`,
+    `association`, `pca`, `topicmodel`, `optiml`.
+    E.g. `{"cluster": {"critical_value": 4},
+           "anomaly": {"forest_size": 256},
+           "optiml": {"number_of_model_candidates": 64}}`
 
 **WARNING** To avoid confusion, `configuration-params` are always
 overwritten by the corresponding input in `automl-execution` if this

--- a/automl/automl-script/readme.md
+++ b/automl/automl-script/readme.md
@@ -15,9 +15,10 @@ be automatically done:
 -  `Feature Generation`: Using the unsupervised models created
   previously to append automatically generated new features to all the
   user given datasets.
-- `Feature Selection`: Reducing, automatically,
-  the number of fields of the datasets using the **Recursive Feature
-  Eliminination** algorithm.
+- `Feature Selection`: Reducing, automatically, the number of fields
+  of the datasets using the **Recursive Feature Eliminination**
+  algorithm. This step is bypassed if the total number of fields is
+  lower than 50 (or 30 if `shallow_search` is `True`)
 -  `Model Selection` Using OptiML to find the best models and using
   the top 3 models to create a `Fusion` model to predict all the test
   dataset instances. If a validation dataset is given, this script
@@ -48,9 +49,10 @@ The **inputs** for the script are:
 * `shallow-search`: (boolean) If true, AutoML will perform a more
   shallow (but faster) search of the best features and models. A
   ramdomly sampled dataset will be used in some stages of the process,
-  only one association discovery will be created (with lift metric)
-  and the maximum training time of the OptiML will be more
-  limited. Default value is `False`.
+  only one association discovery will be created (with lift metric),
+  the objective number of features to obtain from the feature
+  selection process will be fixed to 30 and the maximum training time
+  of the OptiML will be more limited. Default value is `True`.
 * `configuration-params`: (map) Execution configuration
   parameters. They will be overwritten if automl-execution is
   given. The following values must be provided:

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -34,7 +34,7 @@
 (check-excluded-models (config "excluded-models"))
 (log-info "More configuration parameters checks")
 (check-params (config "pca-variance-threshold")
-              (config "max-associations-rules")
+              (config "max-association-rules")
               (config "validation-rate"))
 
 (define [validation-split-dataset train-split-dataset]
@@ -53,6 +53,19 @@
          {"name" (str name " - Train " (* 100 (- 1 rate)) "%")}))
       [validation-dataset (get-input "train-dataset")])))
 
+(define (sampled-ds-maybe ds-id shallow)
+  (let (columns (resource-property (wait ds-id) "columns")
+        rows (resource-property ds-id "rows")
+        name (resource-name ds-id)
+        ;; The sampled dataset should contain at least 20
+        ;; rows per dataset column
+        ratio (/ (* columns 20) rows))
+    (log-info "Sampling dataset with ratio: " ratio)
+    (if (or (> ratio 1) (not shallow))
+      ds-id
+      (create-dataset ds-id {"sample_rate" ratio
+                             "name" (str name " - sampled")}))))
+
 ;; Retrieve all non-preferred fields from all the datasets
 (define non-preferred-fields
   (remove-duplicates
@@ -66,17 +79,20 @@
 (log-featured "Feature generation")
 (log-info "Obtaining unsupervised models")
 ;; Returns a list of unsupervised-models from a dataset
-(define (create-unsupervised-models dataset excluded excluded-models)
-  (let (_ (set-non-preferred dataset non-preferred-fields)
+(define (create-unsupervised-models dataset excluded excluded-models shallow)
+  (let (dataset (sampled-ds-maybe dataset shallow)
+        _ (set-non-preferred dataset non-preferred-fields)
         params {"excluded_fields" (field-ids-from-names excluded dataset)}
         objective-id (dataset-get-objective-id dataset)
-        lev-params (merge params {"rhs_predicate" [{"field" objective-id}]
-                                  "search_strategy" "leverage"})
         lift-params (merge params {"rhs_predicate" [{"field" objective-id}]
                                    "search_strategy" "lift"})
+        ;; leverage metric is not used in shallow-search
+        lev-params (when (not shallow)
+                     (merge params {"rhs_predicate" [{"field" objective-id}]
+                                    "search_strategy" "leverage"}))
         all-models
         (map (lambda (type params*)
-               (when (create-unsupervised? type excluded-models)
+               (when (and (create-unsupervised? type excluded-models) params*)
                  (let (opt (merge params*
                                   ((config "models-configuration") type {})))
                    (create-unsupervised type dataset opt))))
@@ -95,14 +111,17 @@
         exc-models (config "excluded-models"))
     (if reuse-resources
       (get-unsupervised-models automl-execution exc-models)
-      (create-unsupervised-models train-split-dataset exc-fields exc-models))))
+      (create-unsupervised-models train-split-dataset
+                                  exc-fields
+                                  exc-models
+                                  shallow-search))))
 
 (log-info "Generating new features from unsupervised models")
 (define (feature-generation dataset-id
                             model-list
                             excluded
                             pca-threshold
-                            max-associations-rules)
+                            max-rules)
   (let (excluded (remove-false (field-ids-from-names excluded dataset-id))
         objective-id (dataset-get-objective-id dataset-id)
         name (resource-name dataset-id)
@@ -122,7 +141,7 @@
                                          model-list
                                          name
                                          excluded
-                                         max-associations-rules)
+                                         max-rules)
         all-fields [cluster-fields anomaly-fields topic-fields pca-fields]
         all-ds (cons dataset-assoc (map batch-output-ds all-fields)))
     (feature-generation-dataset all-ds name objective-id non-preferred-fields)))
@@ -130,7 +149,7 @@
 (define extended-datasets
   (let (exc-fields (config "excluded-fields")
         pca-threshold (config "pca-variance-threshold")
-        max-associations-rules (floor (config "max-associations-rules")))
+        max-rules (floor (config "max-association-rules")))
     (map (lambda(dataset)
            (when (= (resource-type dataset) "dataset")
              (log-info " - Extending dataset: " (resource-name dataset))
@@ -138,7 +157,7 @@
                                  unsupervised-models
                                  exc-fields
                                  pca-threshold
-                                 max-associations-rules)))
+                                 max-rules)))
          [train-split-dataset validation-split-dataset test-dataset])))
 
 
@@ -152,12 +171,21 @@
 
 ;; Obtains the most important fields from a dataset
 ;; using recursive feature elimination
-(define (compute-important-fields train test)
+(define (compute-important-fields train test shallow)
   (let (balance (config "balance-objective")
-        rfe-output (recursive-feature-elimination train 1 "" test "" balance)
+        train (wait (sampled-ds-maybe train shallow))
+        rfe-output (if shallow
+                     ;; If shallow-search, fixed number
+                     ;; of columns  after rfe, 30
+                     ;; No evaluations
+                     (rfe train 30 "" ""   "" balance)
+                     (rfe train  1 "" test "" balance))
         evaluations (rfe-output "evaluations" {})
-        num-features (rfe-best-num-features evaluations))
-    (rfe-output-fields train evaluations num-features)))
+        num-features (if shallow
+                       30
+                       (rfe-best-num-features evaluations)))
+    (rfe-output-fields train rfe-output num-features shallow)))
+
 
 ;; Obtains the most important fields (a list with their names)
 ;; from a train and an optional test dataset
@@ -168,7 +196,7 @@
           [train* test*] (if (= "dataset" (resource-type valid))
                            [train valid]
                            (wait* (create-random-dataset-split train 0.8))))
-      (compute-important-fields train* test*))))
+      (compute-important-fields train* test* shallow-search))))
 
 (log-info "Filtering the datasets")
 ;; Creates the filtered datasets from the extended datasets,
@@ -193,7 +221,8 @@
       (fusion-from-optiml
        (create-optiml-model train
                             valid
-                            ((config "models-configuration") "optiml" {}))
+                            ((config "models-configuration") "optiml" {})
+                            shallow-search)
        3))))
 
 

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -188,9 +188,7 @@
                      (rfe train min-fields "" test "" balance))
         evaluations (rfe-output "evaluations" {})
         num-features (if shallow
-                       (if (> num-fields min-fields-shallow)
-                         min-fields-shallow
-                         num-fields)
+                       (min num-fields min-fields-shallow)
                        (if (> num-fields min-fields)
                          (rfe-best-num-features evaluations)
                          num-fields)))

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -29,12 +29,12 @@
                        test-dataset)
 (log-info "Check configuration params")
 (check-configuration-params config)
-(check-models-configuration models-configuration)
+(check-models-configuration (config "models-configuration"))
 (log-info "Checking excluded-models")
 (check-excluded-models (config "excluded-models"))
 (log-info "More configuration parameters checks")
 (check-params (config "pca-variance-threshold")
-              (config "max-rules")
+              (config "max-associations-rules")
               (config "validation-rate"))
 
 (define [validation-split-dataset train-split-dataset]
@@ -77,7 +77,8 @@
         all-models
         (map (lambda (type params*)
                (when (create-unsupervised? type excluded-models)
-                 (let (opt (merge params* (models-configuration type {})))
+                 (let (opt (merge params*
+                                  ((config "models-configuration") type {})))
                    (create-unsupervised type dataset opt))))
         ["association" "association" "cluster" "anomaly" "pca" "topicmodel"]
         [lev-params lift-params params params params params]))
@@ -101,7 +102,7 @@
                             model-list
                             excluded
                             pca-threshold
-                            max-rules)
+                            max-associations-rules)
   (let (excluded (remove-false (field-ids-from-names excluded dataset-id))
         objective-id (dataset-get-objective-id dataset-id)
         name (resource-name dataset-id)
@@ -121,7 +122,7 @@
                                          model-list
                                          name
                                          excluded
-                                         max-rules)
+                                         max-associations-rules)
         all-fields [cluster-fields anomaly-fields topic-fields pca-fields]
         all-ds (cons dataset-assoc (map batch-output-ds all-fields)))
     (feature-generation-dataset all-ds name objective-id non-preferred-fields)))
@@ -129,7 +130,7 @@
 (define extended-datasets
   (let (exc-fields (config "excluded-fields")
         pca-threshold (config "pca-variance-threshold")
-        max-rules (floor (config "max-rules")))
+        max-associations-rules (floor (config "max-associations-rules")))
     (map (lambda(dataset)
            (when (= (resource-type dataset) "dataset")
              (log-info " - Extending dataset: " (resource-name dataset))
@@ -137,7 +138,7 @@
                                  unsupervised-models
                                  exc-fields
                                  pca-threshold
-                                 max-rules)))
+                                 max-associations-rules)))
          [train-split-dataset validation-split-dataset test-dataset])))
 
 
@@ -192,7 +193,7 @@
       (fusion-from-optiml
        (create-optiml-model train
                             valid
-                            (models-configuration "optiml" {}))
+                            ((config "models-configuration") "optiml" {}))
        3))))
 
 

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -174,16 +174,26 @@
 (define (compute-important-fields train test shallow)
   (let (balance (config "balance-objective")
         train (wait (sampled-ds-maybe train shallow))
+        num-fields (count (keys (resource-fields train)))
+        min-fields-shallow 30
+        min-fields 50
         rfe-output (if shallow
                      ;; If shallow-search, fixed number
-                     ;; of columns  after rfe, 30
+                     ;; of fields  after rfe, 30
                      ;; No evaluations
-                     (rfe train 30 "" ""   "" balance)
-                     (rfe train  1 "" test "" balance))
+                     (rfe train min-fields-shallow "" ""   "" balance)
+                     ;; We want, at least 50 fields. If the total
+                     ;; number of fields is lower, we will skip
+                     ;; feature selection stage
+                     (rfe train min-fields "" test "" balance))
         evaluations (rfe-output "evaluations" {})
         num-features (if shallow
-                       30
-                       (rfe-best-num-features evaluations)))
+                       (if (> num-fields min-fields-shallow)
+                         min-fields-shallow
+                         num-fields)
+                       (if (> num-fields min-fields)
+                         (rfe-best-num-features evaluations)
+                         num-fields)))
     (rfe-output-fields train rfe-output num-features shallow)))
 
 

--- a/stratified-sampling/script.whizzml
+++ b/stratified-sampling/script.whizzml
@@ -2,7 +2,7 @@
 ;; categories in that field, and breaks the dataset into pieces, one
 ;; per category. Returns the list of datasets.
 (define (split-it ds-id fld-id bucket-list)
-  (iterate (ds-list []            
+  (iterate (ds-list []
             bucket bucket-list)
     (let (split-filter (flatline "(= (f {{fld-id}}) {{bucket}})")
           split-ds (create-and-wait-dataset ds-id
@@ -16,21 +16,21 @@
   (iterate (ds-list []
             ds split-list
             sample-size sample-list)
-    (let (ds-size ((fetch ds) "rows"))
+    (let (ds-size ((fetch (wait ds)) "rows"))
       (append ds-list (create-dataset ds
                       {"sample_rate" (min (/ sample-size ds-size) 1.0 )})))))
 
 ;; Given a dataset-id, a categorical field-id, and a map of weights, computes
 ;; the relative counts from the class distribution
-(define (weighted-counts ds-id field-id weights) 
+(define (weighted-counts ds-id field-id weights)
   (let (dists (field-distribution (find-field (resource-fields ds-id) field-id))
         class-values (keys weights)
-        smallest-factor 
-          (min (iterate (ratios [] dist dists) 
+        smallest-factor
+          (min (iterate (ratios [] dist dists)
                  (append ratios (floor (/ (dist 1) (weights (dist 0))))))))
-    (iterate (counts [] class-val class-values) 
+    (iterate (counts [] class-val class-values)
       (append counts (* smallest-factor (weights class-val))))))
-      
+
 ;; Putting it together, takes in a dataset, a field id/name, and a map of
 ;; field values to sample counts. Breaks the dataset into pieces by
 ;; field value, samples them according to the sample counts, and puts
@@ -39,7 +39,7 @@
 (define (stratified-sampling ds-id field sample-map weighted)
   (let (field-id (get (find-field (resource-fields ds-id) field) "id")
         field-values (keys sample-map)
-        sample-count (if weighted 
+        sample-count (if weighted
           (weighted-counts ds-id field-id sample-map)
           (values sample-map))
         split-list (split-it ds-id field-id field-values)


### PR DESCRIPTION
The new parameter `shallow_search` let the user do a more shallow (but faster) execution.

As far I have seen, accuracy results are very similar (even better sometimes) to the ones obtained with `shallow_search=False`
but executions are much faster.

I ran a benchmark and the results seems to be very good:

  | dataset    | AutoML Phi | AutoML(shallow) Phi | OptiML Phi | AutoML Time (min) | AutoML (shallow) Time (min) | OptiML Time (min) |
|-----------|----------|-----------|-----------|------------|--------------|-----------|
   | adult       |  0.6018  |     0.6089 |  0.6060 |      100 |           39 |       70 |
   | breast     |  0.9810  |     0.9427 |  0.9433 |       24 |           11 |       24 |
   | diabetes |  0.4433  |     0.5187 |  0.4491 |       29 |           12 |       27 |
   | har          |  0.9489  |     0.9301 |  0.9159 |      220 |          140 |       90 |
   | satellite   |  0.8875  |     0.8939 |  0.8770 |      156 |           50 |       61 |
   | sonar       |  0.7646 |     0.7202 |  0.7124 |      140 |           49 |       49 |
   | vehicle    |  0.6936  |     0.7411 |  0.7530 |       39 |           19 |       38 |
   | votes       |    0.9751 |     0.9751 |  0.9280 |       45 |           24 |       25 |

Some more changes:

   - Fix bug in **stratified-sampling** script
   - **Feature Selection** step is bypassed if the total number of
     fields is lower than 50 (or 30 if shallow_search is True)
   - `models-configuration` parameter appears within `configuration-params`
      map, to show a cleaner execution interface
   - `max-rules` -> `max-associations rules`
   - `pca-variance-threshold` to 0.6 by default, because we don't need
      all the Principal Components
   - Unsupervised models are created from sampled dataset if `shallow_search` is `True`
   - **RFE** is executed from sampled dataset and with a fix objective number
     of columns: 30 (if `shallow_search`)
   - `max-association-rules` refers now to the maximum number of rules
     obtained from each association discovery
   - Limited time of **OptiML**
   - Only one **association discovery** is created when `shallow_search`

