### PR TITLE
Improving the manage-projects script.

### DIFF
--- a/manage-projects/readme.md
+++ b/manage-projects/readme.md
@@ -9,6 +9,13 @@ in one execution of the script (default=10). The goal of the execution can be
 either list the projects, archive their resources in a new project and
 delete them, or delete the projects and the resources therein.
 
+When archiving, a new project is created to contain the archived resources.
+The name of the project is "Archive - " followed by the date it was created.
+Also, a "bigml-archive" tag is added to the project. Also, a tag that contains
+the old project ID is added to each archived resource, and the name and ID of
+the original project is added to the `user_metadata` attribute as `project_id`
+and `project_name`.
+
 **DISCLAIMER**: Please, note that the `delete` option will cause the deletion
 of the projects and the resources therein and is a non-undoable operation.
 Use that at your own risk.

--- a/manage-projects/readme.md
+++ b/manage-projects/readme.md
@@ -16,6 +16,10 @@ the old project ID is added to each archived resource, and the name and ID of
 the original project is added to the `user_metadata` attribute as `project_id`
 and `project_name`.
 
+**IMPORTANT**: To run the script using the Dashboard, please remember
+to get out of any of the projects that you want to select for deletion or
+archive.
+
 **DISCLAIMER**: Please, note that the `delete` option will cause the deletion
 of the projects and the resources therein and is a non-undoable operation.
 Use that at your own risk.

--- a/manage-projects/script.whizzml
+++ b/manage-projects/script.whizzml
@@ -85,7 +85,7 @@
 (define (merged-updates ids changes)
   (iterate (acc [] id ids)
     (if (= "sample" (resource-type id))
-      (proc
+      (prog
         (log-info "The sample " id  " will not be archived")
         acc)
       (let (resource (fetch id)

--- a/manage-projects/script.whizzml
+++ b/manage-projects/script.whizzml
@@ -138,7 +138,7 @@
       (log-info "  " type ": " (counter type "\n")))
     (if (= action "list")
         (log-info text-list)
-        (let (new-project (when (= action "archive")
+        (let (new-project (when (and (= action "archive") (> (count ids) 0))
                                 (create-archive)))
           (for (id ids)
             (log-info "Acting on resource: " id)

--- a/manage-projects/script.whizzml
+++ b/manage-projects/script.whizzml
@@ -83,13 +83,17 @@
 ;; Updating the resources with the new project and the info about the
 ;; original project when archiving them
 (define (merged-updates ids changes)
-  (for (id ids)
-    (let (resource (fetch id)
-          tags (concat (resource "tags") (changes "tags"))
-          user-metadata (merge (resource "user_metadata")
-                               (changes "user_metadata")))
-      (update id {"tags" tags "user_metadata" user-metadata
-                  "project" (changes "project")}))))
+  (iterate (acc [] id ids)
+    (if (= "sample" (resource-type id))
+      (proc
+        (log-info "The sample " id  " will not be archived")
+        acc)
+      (let (resource (fetch id)
+            tags (concat (resource "tags") (changes "tags"))
+            user-metadata (merge (resource "user_metadata")
+                                 (changes "user_metadata")))
+        (append acc (update id {"tags" tags "user_metadata" user-metadata
+                                "project" (changes "project")}))))))
 
 ;; Deleting or updating the resources in a list in batches to avoid timeouts
 (define (act-in-batches a-list changes action limit)
@@ -103,7 +107,8 @@
 
 ;; Creating an archive project
 (define (create-archive)
-  (let (new-project (fetch (create-project {"name" "Archive"}))
+  (let (new-project (fetch (create-project {"name" "Archive"
+                                            "tags" ["bigml-archive"]}))
         date (replace (new-project "created") "T" " "))
    (update (wait (new-project "resource")) {"name" (str "Archive - " date)})))
 


### PR DESCRIPTION
- Avoid failing when archiving samples
- Explaining tags and adding a new `bigml-archive` tag to the Archive project
- Warning about runing the script from a selected project