### PR TITLE
 Fix in AutoML: Wait Only retrieve associations fields once

### DIFF
--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -263,9 +263,8 @@
         (str "(not (missing? (f \"" field-name "\")))")
         (str "(missing? (f \"" field-name "\"))")))))
 
-(define (_describe-rule association rule-id match)
-  (let (fields (resource-fields association)
-        associations (association "associations" {})
+(define (_describe-rule association fields rule-id match)
+  (let (associations (association "associations" {})
         items (associations "items" [])
         rules (associations "rules" [])
         rule (try (head (filter (lambda (r) (= (r "id") rule-id)) rules))
@@ -289,10 +288,9 @@
         total (+ (count lhs) (count rhs)))
     (= total (count (field-names-from-ids (concat lhs rhs) dataset-id)))))
 
-(define (_flatline-rule association rule match dataset-id)
+(define (_flatline-rule association fields rule match dataset-id)
   (when (_check-assoc-field-exists association rule dataset-id)
-    (let (fields (resource-fields association)
-          associations (association "associations" {})
+    (let (associations (association "associations" {})
           items (associations "items" [])
           get-item-fn
           (lambda (i) (_flatline-item (items i) (fields ((items i) "field_id"))))
@@ -311,12 +309,14 @@
             (str "(and " lhs " " rhs ")")))))
 
 (define (_batch-association-sets dataset-id association-id match max-rules)
-  (let (association (fetch association-id)
+  (let (association (fetch (wait association-id))
         associations (association "associations" {})
         rules (associations "rules" [])
+        fields (resource-fields association)
         flatline-rules (take max-rules
                              (map (lambda (rule)
                                     (_flatline-rule association
+                                                    fields
                                                     rule
                                                     match
                                                     dataset-id))
@@ -326,6 +326,7 @@
                      (if flatline-rule
                        (append acc {"field" flatline-rule
                                     "name" (_describe-rule association
+                                                           fields
                                                            (rule "id")
                                                            match)
                                     "label" (str (association "name")

--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -1,5 +1,5 @@
 ;;;;;;;;;;;;;;;;;;;;;;; AUTOML LIBRARY ;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;; library version 0.8 ;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;; library version 0.8.1 ;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;; Private functions start with _ ;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;; Check automl script ;;;;;;;;;;;;;;;;;;;;;
 
@@ -86,7 +86,7 @@
 
 ;; Set a list of fields from a dataset as non-preferred
 (define (set-non-preferred dataset-id field-names)
-  (let (fids (field-ids-from-names field-names dataset-id)
+  (let (fids (field-ids-from-names field-names (wait dataset-id))
         fvalues (repeat (count fids) {"preferred" false}))
     (update dataset-id {"fields" (make-map fids fvalues)})))
 

--- a/automl/automl-library/library.whizzml
+++ b/automl/automl-library/library.whizzml
@@ -63,7 +63,7 @@
 ;; Returns a list of field ids from a list of field names
 ;; Not found fields are ignored
 (define (field-ids-from-names field-names dataset)
-  (let (dataset-fields (resource-fields dataset))
+  (let (dataset-fields (resource-fields (wait dataset)))
     (remove-false
      (map (lambda(f) (get (or (find-field dataset-fields f) {}) "id" false))
           field-names))))
@@ -80,13 +80,13 @@
 ;; from a given dataset
 (define (non-preferred dataset-id)
   (when (= (resource-type dataset-id) "dataset")
-    (let (fields (resource-fields dataset-id))
+    (let (fields (resource-fields (wait dataset-id)))
       (filter (lambda (k) (not (fields [k "preferred"] true)))
               (keys fields)))))
 
 ;; Set a list of fields from a dataset as non-preferred
 (define (set-non-preferred dataset-id field-names)
-  (let (fids (field-ids-from-names field-names (wait dataset-id))
+  (let (fids (field-ids-from-names field-names dataset-id)
         fvalues (repeat (count fids) {"preferred" false}))
     (update dataset-id {"fields" (make-map fids fvalues)})))
 

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -68,7 +68,10 @@
 (define non-preferred-fields
   (remove-duplicates
    (flatten
-    (map (lambda(ds) (field-names-from-ids (non-preferred ds) ds))
+    (map (lambda(ds)
+           (if (and ds (> (count (resource-id ds)) 0))
+             (field-names-from-ids (non-preferred (wait ds)) ds)
+             []))
          [train-split validation-split test-dataset]))))
 
 (log-info "These fields will be set as non-preferred:")
@@ -199,10 +202,11 @@
 ;; Obtains the most important fields (a list with their names)
 ;; from a train dataset
 (define selected-fields
-  (if reuse-resources
-    (retrieve-important-fields automl-execution)
-    (let ([train _ _ _] extended-datasets)
-      (compute-important-fields train shallow-search))))
+  (concat non-preferred-fields
+          (if reuse-resources
+            (retrieve-important-fields automl-execution)
+            (let ([train _ _ _] extended-datasets)
+              (compute-important-fields train shallow-search)))))
 
 (log-info "Filtering the datasets")
 ;; Creates the filtered datasets from the extended datasets,
@@ -212,9 +216,10 @@
          (when (= "dataset" (resource-type ds))
            (let (name (str (resource-name ds) " | filtered")
                  fields (field-ids-from-names selected-fields ds))
-             (create-dataset {"name" name
-                              "origin_dataset" ds
-                              "input_fields" (remove-duplicates fields)}))))
+             (set-non-preferred
+              (create-dataset {"name" name  "origin_dataset" ds
+                              "input_fields" (remove-duplicates fields)})
+              non-preferred-fields))))
        extended-datasets))
 
 (log-featured "Model Selection")

--- a/automl/automl-script/script.whizzml
+++ b/automl/automl-script/script.whizzml
@@ -70,7 +70,7 @@
    (flatten
     (map (lambda(ds)
            (if (and ds (> (count (resource-id ds)) 0))
-             (field-names-from-ids (non-preferred (wait ds)) ds)
+             (field-names-from-ids (non-preferred ds) ds)
              []))
          [train-split validation-split test-dataset]))))
 
@@ -218,7 +218,7 @@
                  fields (field-ids-from-names selected-fields ds))
              (set-non-preferred
               (create-dataset {"name" name  "origin_dataset" ds
-                              "input_fields" (remove-duplicates fields)})
+                               "input_fields" (remove-duplicates fields)})
               non-preferred-fields))))
        extended-datasets))
 


### PR DESCRIPTION
I already wrote this in July, but I don't remember I never merged it. It solves a problem reported recently by a user.

This solves two problems:

- sometimes we don't wait associations to finish before retrieving their fields
- non-prefered fields are not shown in filtered datasets
