### PR TITLE
Add cluster-chronological-split whizzml script

### DIFF
--- a/cluster-chronological-split/metadata.json
+++ b/cluster-chronological-split/metadata.json
@@ -1,0 +1,37 @@
+{
+  "name": "Chronological-Cluster-Split",
+  "description": "Splits training and test data chronologically by similarities based on a K-means cluster. Can be helpful to split data chronologically keeping relevant portions in both train and test datasets. Actions:  Trains cluster from input dataset. Processes batch centroid over the same dataset. For each cluster label, creates specific dataset and splits train-test chronologically with given proportions. Merges all train and test portions separately providing a final train and test database. Requirements: The original dataset needs to be ordered chronologically.",
+  "kind": "script",
+  "category": 11,
+  "inputs": [
+    {
+      "name": "dataset-input",
+      "type": "dataset-id",
+      "description": "Dataset to be split"
+    },
+    {
+      "name": "cluster-fields-input",
+      "type": "list",
+      "description": "List of field names to be used when training the cluster. Example: [\"field1\", \"field2\", ... \"field3\"]"
+    },
+    {
+      "name": "num-clusters",
+      "type": "number",
+      "default": 10,
+      "description": "K: number of clusters to be created in the K-means"
+    },
+    {
+      "name": "train-percent",
+      "type": "number",
+      "default": 80,
+      "description": "Percentage proportion for the training dataset"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "return-split-datasets",
+      "type": "map",
+      "description": "Map containing references to the \"training-dataset\" and  \"test-dataset\" datasets respectively."
+    }
+  ]
+}

--- a/cluster-chronological-split/metadata.json
+++ b/cluster-chronological-split/metadata.json
@@ -24,7 +24,13 @@
       "name": "train-percent",
       "type": "number",
       "default": 80,
-      "description": "Percentage proportion for the training dataset"
+      "description": "Percentage proportion for the training dataset (default 80)"
+    },
+    {
+      "name": "default-numeric-value",
+      "type": "string",
+      "default": "mean",
+      "description": "Method to be used to replace numeric missing values (default mean)"
     }
   ],
   "outputs": [

--- a/cluster-chronological-split/readme.md
+++ b/cluster-chronological-split/readme.md
@@ -1,0 +1,16 @@
+# Cluster 10 split
+###Split dataset chronologically into a Training and Test dataset based on a Cluster
+
+* **Inputs:** Given a dataset chronologically ordered, a set of input fields, a K number and a split proportion
+* **Outputs:** Returns a dictionary including a test and training dataset resulting from the implemented split
+
+1. From the input dataset, trains a K-means Cluster (cluster fields and K as an input)
+2. Batch centroid over the original dataset to add K different cluster labels. This way data is separated in K groups of similarity
+3. For each cluster create a new dataset
+4. Split datasets linearly (using a proportion from the input parameter) keeping the latest for test
+5. Merge all train and test datasets portions into the resulting training and test final datasets
+
+Requirements: The input dataset needs to be ordered chronologically (BigML ordering capabilities can be manually used as desired)
+
+Installation command to be executed from the local directory (bigmler needs to be previously installed):
+`bigmler whizzml --package-dir . --output-dir ~/tmp --org-project project/yourProjectId12345

--- a/cluster-chronological-split/script.whizzml
+++ b/cluster-chronological-split/script.whizzml
@@ -1,46 +1,80 @@
 ;; create cluster from inputs
-(define cluster (create-and-wait-cluster {"dataset" dataset-input
-                                           "k" num-clusters
-                                           "default_numeric_value" "mean"
-                                           "input_fields" cluster-fields-input}))
+(define cluster 
+  (create-and-wait-cluster 
+    {"dataset" dataset-input
+     "k" num-clusters
+      "default_numeric_value" default-numeric-value
+      "input_fields" cluster-fields-input}))
 
 ;; batch centroid to label input dataset
-(define batch-centroid (create-and-wait-batchcentroid {"cluster" cluster
-                                                       "dataset" dataset-input
-                                                       "all_fields" true
-                                                       "output_dataset" true}))
+(define batch-centroid 
+  (create-and-wait-batchcentroid 
+    {"cluster" cluster
+     "dataset" dataset-input
+     "all_fields" true
+     "output_dataset" true}))
 
-(define dataset-centroid ((fetch (wait batch-centroid)) ["output_dataset_resource"] false))
+(define dataset-centroid 
+  ((fetch (wait batch-centroid)) 
+    ["output_dataset_resource"] false))
 
 ;; get cluster names from resulting dataset
-(define fields (resource-fields (wait dataset-centroid)))
-(define cluster-field-id ((find-field fields "cluster") "id"))
-(define cluster-names (map head (fields [cluster-field-id "summary" "categories"])))
+(define fields 
+  (resource-fields 
+   (wait dataset-centroid)))
+
+(define cluster-field-id 
+  ((find-field fields "cluster") "id"))
+
+(define cluster-names 
+  (map head 
+    (fields [cluster-field-id "summary" 
+                              "categories"])))
 
 ;; filter centroid dataset for each cluster (returns filtered dataset list with num-clusters elements)
-(define cluster-datasets (map (lambda(x) (create-and-wait-dataset {"origin_dataset" dataset-centroid
-                                                          "lisp_filter" (flatline "(= (f \"cluster\") {{x}})")
-                                                          "excluded_fields" ["cluster"]})) cluster-names))
+(define cluster-datasets 
+  (map (lambda(x) 
+          (create-and-wait-dataset {"origin_dataset" dataset-centroid
+                                    "lisp_filter" (flatline "(= (f \"cluster\") {{x}})")
+                                    "excluded_fields" ["cluster"]})) 
+           cluster-names))
 
 ;; count rows for each dataset inside a new list
-(define num-rows (map (lambda (x) ((fetch x) "rows")) cluster-datasets))
-(define num-train-rows (map (lambda (x) (round (* (/ x 100) train-percent))) num-rows))
+(define num-rows 
+  (map (lambda (x) 
+          ((fetch x) "rows")) 
+           cluster-datasets))
+
+(define num-train-rows 
+  (map (lambda (x) 
+          (round (* (/ x 100) train-percent))) 
+           num-rows))
 
 ;; split cluster datasets
-(define train-datasets (map (lambda (x y)
-                                    (create-and-wait-dataset {"origin_dataset" x "range" [1, y]}))
-                             cluster-datasets
-                             num-train-rows))
+(define train-datasets 
+  (map (lambda (x y)
+          (create-and-wait-dataset {"origin_dataset" x 
+                                    "range" [1 y]}))
+           cluster-datasets
+           num-train-rows))
 
-(define test-datasets (map (lambda (x y z)
-                                    (create-and-wait-dataset {"origin_dataset" x "range" [(+ 1 y), z]}))
-                             cluster-datasets
-                             num-train-rows
-                             num-rows))
+(define test-datasets 
+  (map (lambda (x y z)
+          (create-and-wait-dataset {"origin_dataset" x 
+                                    "range" [(+ 1 y) z]}))
+           cluster-datasets
+           num-train-rows
+           num-rows))
 
 ;; build train and test datasets
-(define dataset-train (create-and-wait-dataset {"origin_datasets" train-datasets}))
-(define dataset-test (create-and-wait-dataset {"origin_datasets" test-datasets}))
+(define dataset-train 
+  (create-and-wait-dataset 
+    {"origin_datasets" train-datasets}))
+(define dataset-test 
+  (create-and-wait-dataset 
+    {"origin_datasets" test-datasets}))
 
 
-(define return-split-datasets {"training-dataset" dataset-train "test-dataset" dataset-test})
+(define return-split-datasets 
+  {"training-dataset" dataset-train 
+   "test-dataset" dataset-test})

--- a/cluster-chronological-split/script.whizzml
+++ b/cluster-chronological-split/script.whizzml
@@ -1,0 +1,46 @@
+;; create cluster from inputs
+(define cluster (create-and-wait-cluster {"dataset" dataset-input
+                                           "k" num-clusters
+                                           "default_numeric_value" "mean"
+                                           "input_fields" cluster-fields-input}))
+
+;; batch centroid to label input dataset
+(define batch-centroid (create-and-wait-batchcentroid {"cluster" cluster
+                                                       "dataset" dataset-input
+                                                       "all_fields" true
+                                                       "output_dataset" true}))
+
+(define dataset-centroid ((fetch (wait batch-centroid)) ["output_dataset_resource"] false))
+
+;; get cluster names from resulting dataset
+(define fields (resource-fields (wait dataset-centroid)))
+(define cluster-field-id ((find-field fields "cluster") "id"))
+(define cluster-names (map head (fields [cluster-field-id "summary" "categories"])))
+
+;; filter centroid dataset for each cluster (returns filtered dataset list with num-clusters elements)
+(define cluster-datasets (map (lambda(x) (create-and-wait-dataset {"origin_dataset" dataset-centroid
+                                                          "lisp_filter" (flatline "(= (f \"cluster\") {{x}})")
+                                                          "excluded_fields" ["cluster"]})) cluster-names))
+
+;; count rows for each dataset inside a new list
+(define num-rows (map (lambda (x) ((fetch x) "rows")) cluster-datasets))
+(define num-train-rows (map (lambda (x) (round (* (/ x 100) train-percent))) num-rows))
+
+;; split cluster datasets
+(define train-datasets (map (lambda (x y)
+                                    (create-and-wait-dataset {"origin_dataset" x "range" [1, y]}))
+                             cluster-datasets
+                             num-train-rows))
+
+(define test-datasets (map (lambda (x y z)
+                                    (create-and-wait-dataset {"origin_dataset" x "range" [(+ 1 y), z]}))
+                             cluster-datasets
+                             num-train-rows
+                             num-rows))
+
+;; build train and test datasets
+(define dataset-train (create-and-wait-dataset {"origin_datasets" train-datasets}))
+(define dataset-test (create-and-wait-dataset {"origin_datasets" test-datasets}))
+
+
+(define return-split-datasets {"training-dataset" dataset-train "test-dataset" dataset-test})


### PR DESCRIPTION
Adding a new WhizzML script coming from a project into the WhizzML-examples folder.
The script is about splitting data chronologically by similarity using a cluster. The original dataset to be split is used to train a cluster and a posterior batch centroid. Dividing the data into N groups by similarity. Then the data (requirement is that the input dataset is ordered chronologically) is split in each cluster chronologically. Finally all cluster train and test portions are merged respectively, resulting into the output: a training and a test dataset resulting from this specific split.
The data split performed is suitable with time dependent data where random splits need to be avoid. In the mean time the resulting split also ensures that both training and test datasets contain a portion of data from each cluster, being more representative of all data typologies available.
The original skeleton comes from a scriptify execution but has deeply been adapted manually with the help of Mercè (thanks)